### PR TITLE
Unit tests + cleanup + refactoring

### DIFF
--- a/lib/DataObjects/Locker.go
+++ b/lib/DataObjects/Locker.go
@@ -1,4 +1,4 @@
-package DataObjects
+package dataobjects
 
 import (
 	"bufio"
@@ -6,13 +6,16 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	global "../Global"
 	SQL "../Sql/Proxy"
-	Global "../Global"
+
 	//"github.com/go-sql-driver/mysql"
-	log "github.com/sirupsen/logrus"
 	"os"
 	"strconv"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
 
 type (
@@ -20,115 +23,118 @@ type (
 	//Locker initialize also the ProxySQL node that will execute the actions
 
 	Locker struct {
-		MyServerIp          string
-		MyServerPort        int
-		MyServer            *ProxySQLNode
-		myConfig			*Global.Configuration
-		FileLock            string
-		FileLockPath        string
-		FileLockInterval    int64
-		FileLockReset       bool
-		ClusterLockId       string
-		ClusterLockInterval int64
-		ClusterLockReset    bool
-		ClusterLastLockTime	int64
+		MyServerIp             string
+		MyServerPort           int
+		MyServer               *ProxySQLNode
+		myConfig               *global.Configuration
+		FileLock               string
+		FileLockPath           string
+		FileLockInterval       int64
+		FileLockReset          bool
+		ClusterLockId          string
+		ClusterLockInterval    int64
+		ClusterLockReset       bool
+		ClusterLastLockTime    int64
 		ClusterCurrentLockTime int64
-		IsClusterLocked     bool
-		IsFileLocked        bool
-		isLooped		    bool
-		LockFileTimeout int64
-		LockClusterTimeout int64
+		IsClusterLocked        bool
+		IsFileLocked           bool
+		isLooped               bool
+		LockFileTimeout        int64
+		LockClusterTimeout     int64
 	}
 )
 
 //Initialize the locker
 //TODO initialize
-func (locker *Locker) Init(config *Global.Configuration) bool{
+func (locker *Locker) Init(config *global.Configuration) bool {
 	locker.myConfig = config
-	locker.MyServerIp = config.Proxysql.Host
-	locker.MyServerPort = config.Proxysql.Port
+	locker.MyServerIp = config.ProxySQL.Host
+	locker.MyServerPort = config.ProxySQL.Port
 	var MyServer = new(ProxySQLNode)
 	locker.MyServer = MyServer
 	locker.MyServer.Ip = locker.MyServerIp
-	locker.FileLockPath = config.Proxysql.LockFilePath
+	locker.FileLockPath = config.ProxySQL.LockFilePath
 	locker.isLooped = config.Global.Daemonize
 	locker.LockFileTimeout = config.Global.LockFileTimeout
 	locker.LockClusterTimeout = config.Global.LockClusterTimeout
 
 	// Set lock file name based on the PXC cluster ID + HGs
-	locker.ClusterLockId = strconv.Itoa(config.Pxcluster.ClusterId) +
-		"_HG_" + strconv.Itoa(config.Pxcluster.HgW) +
-		"_W_HG_" + strconv.Itoa(config.Pxcluster.HgR) +
+	locker.ClusterLockId = strconv.Itoa(config.PxcCluster.ClusterID) +
+		"_HG_" + strconv.Itoa(config.PxcCluster.HgW) +
+		"_W_HG_" + strconv.Itoa(config.PxcCluster.HgR) +
 		"_R"
 	locker.FileLock = locker.ClusterLockId
 
 	log.Info("Locker initialized")
 	return true
 }
+
 //TODO fill the method
-func (locker *Locker) CheckFileLock() *ProxySQLNode{
+func (locker *Locker) CheckFileLock() *ProxySQLNode {
 
 	log.Info("")
 
 	return locker.MyServer
 }
+
 // we will check if the node were we are has a lock or if can acquire one.
 // If not we will return nil to indicate program must exit given either there is already another node holding the lock
 // or this node is not in a good state to acquire a lock
 // Outside call To get and check the active list of ProxySQL server we call ProxySQLCLuster.GetProxySQLnodes
 // All the DB operations are done connecting locally to the ProxySQL node running the scheduler
 
-func (locker *Locker) CheckClusterLock( ) *ProxySQLNode{
+func (locker *Locker) CheckClusterLock() *ProxySQLNode {
 	//TODO
 	// 1 get connection
 	// 2 get all we need from ProxySQL
 	// 3 put the lock if we can
-	Global.SetPerformanceObj("Cluster lock", true, log.InfoLevel)
+	global.SetPerformanceObj("Cluster lock", true, log.InfoLevel)
 	proxySQLCluster := new(ProxySQLCluster)
 	if !locker.MyServer.IsInitialized {
-		if !locker.MyServer.Init(locker.myConfig){
-			Global.SetPerformanceObj("Cluster lock", false, log.InfoLevel)
+		if !locker.MyServer.Init(locker.myConfig) {
+			global.SetPerformanceObj("Cluster lock", false, log.InfoLevel)
 			return nil
 		}
 	}
 	if locker.MyServer.IsInitialized {
-		proxySQLCluster.User = locker.myConfig.Proxysql.User
-		proxySQLCluster.Password = locker.myConfig.Proxysql.Password
+		proxySQLCluster.User = locker.myConfig.ProxySQL.User
+		proxySQLCluster.Password = locker.myConfig.ProxySQL.Password
 		//myMap := new(map[string]ProxySQLNode)
 		//log.Info(myMap)
 		proxySQLCluster.Nodes = make(map[string]ProxySQLNode)
-		if proxySQLCluster.GetProxySQLnodes(locker.MyServer) && len(proxySQLCluster.Nodes) > 0{
+		if proxySQLCluster.GetProxySQLnodes(locker.MyServer) && len(proxySQLCluster.Nodes) > 0 {
 			if nodes, ok := locker.findLock(proxySQLCluster.Nodes); ok && nodes != nil {
-				if locker.PushSchedulerLock(nodes){
-					Global.SetPerformanceObj("Cluster lock", false, log.InfoLevel)
+				if locker.PushSchedulerLock(nodes) {
+					global.SetPerformanceObj("Cluster lock", false, log.InfoLevel)
 					return locker.MyServer
-				}else{
-					Global.SetPerformanceObj("Cluster lock", false, log.InfoLevel)
+				} else {
+					global.SetPerformanceObj("Cluster lock", false, log.InfoLevel)
 					return nil
 				}
-			}else{
-				log.Info(fmt.Sprintf("Cannot put a lock on the cluster for this scheduler %s another node hold the lock and acting",locker.MyServer.Dns))
-				Global.SetPerformanceObj("Cluster lock", false, log.InfoLevel)
+			} else {
+				log.Info(fmt.Sprintf("Cannot put a lock on the cluster for this scheduler %s another node hold the lock and acting", locker.MyServer.Dns))
+				global.SetPerformanceObj("Cluster lock", false, log.InfoLevel)
 				return nil
 			}
 		}
 	}
 
-	Global.SetPerformanceObj("Cluster lock", false, log.InfoLevel)
+	global.SetPerformanceObj("Cluster lock", false, log.InfoLevel)
 	return locker.MyServer
 }
+
 /*
-Find lock method review all the nodes existing in the Proxysql for an active LOck
+Find lock method review all the nodes existing in the ProxySQL for an active LOck
 it checks only nodes that are reachable.
 Checks for:
 	- existing lock locally
 	- lock on another node
 	- lock time comparing it with lockclustertimeout parameter
- */
-func (locker *Locker) findLock(nodes map[string]ProxySQLNode)  (map[string]ProxySQLNode,bool){
+*/
+func (locker *Locker) findLock(nodes map[string]ProxySQLNode) (map[string]ProxySQLNode, bool) {
 	lockText := ""
-	winningNode :=  ""
-	lockHeader := "#LOCK_" + locker.ClusterLockId +"_"
+	winningNode := ""
+	lockHeader := "#LOCK_" + locker.ClusterLockId + "_"
 	lockTail := "_LOCK#"
 	lockHeaderLen := len(lockHeader)
 	log.Debug("Using lock ID: ", lockHeader)
@@ -140,19 +146,18 @@ func (locker *Locker) findLock(nodes map[string]ProxySQLNode)  (map[string]Proxy
 	for _, node := range nodes {
 		lockText = node.Comment
 
-
 		// the node we are parsing hold a LOCK
 		if strings.Contains(lockText, lockHeader) {
 			node.HoldLock = true
 
 			startIdx := strings.Index(node.Comment, lockHeader)
 			endIdx := strings.Index(node.Comment, lockTail)
-			lockText := node.Comment[startIdx + lockHeaderLen : endIdx]
+			lockText := node.Comment[startIdx+lockHeaderLen : endIdx]
 
 			log.Debug(fmt.Sprintf("Cluster Node %s has a scheduler lock ", node.Dns))
 
 			//get LOCK time and assign as winning node the node that has be the more recent one
-			node.LastLockTime = int64(Global.ToInt(lockText))
+			node.LastLockTime = int64(global.ToInt(lockText))
 
 			//Also if the time is not expired I will remove the lock text from comment for my node, given if the lock on another node is active I will not do a thing.
 			//But if is not I will have the comment in the node ready
@@ -183,19 +188,20 @@ func (locker *Locker) findLock(nodes map[string]ProxySQLNode)  (map[string]Proxy
 
 	// My ProxySQL node is the winner and I can push a lock on it
 	// Else I exit without doing a bit
-	if winningNode == "" || winningNode == locker.MyServer.Dns{
-		node :=  nodes[locker.MyServer.Dns]
+	if winningNode == "" || winningNode == locker.MyServer.Dns {
+		node := nodes[locker.MyServer.Dns]
 		if node.Dns != "" {
 			node.Comment = node.Comment + " " + lockHeader + strconv.FormatInt(locker.ClusterCurrentLockTime, 10) + lockTail
 			nodes[locker.MyServer.Dns] = node
 			log.Debug(fmt.Sprintf("Lock acquired by node %s Current time %d", locker.MyServer.Dns, locker.ClusterCurrentLockTime))
 		}
 
-		return  nodes, true
+		return nodes, true
 	}
-	return nil,false
+	return nil, false
 
 }
+
 // We are ready to submit our changes. As always all is executed in a transaction
 // TODO SHOULD we remove the proxysql node that doesn't work ????
 func (locker *Locker) PushSchedulerLock(nodes map[string]ProxySQLNode) bool {
@@ -203,8 +209,8 @@ func (locker *Locker) PushSchedulerLock(nodes map[string]ProxySQLNode) bool {
 		return true
 	}
 
-	if Global.Performance {
-		Global.SetPerformanceObj("Execute SQL changes - ProxySQL cluster LOCK ("+ locker.ClusterLockId +")" , true,log.DebugLevel)
+	if global.Performance {
+		global.SetPerformanceObj("Execute SQL changes - ProxySQL cluster LOCK ("+locker.ClusterLockId+")", true, log.DebugLevel)
 	}
 	//We will execute all the commands inside a transaction if any error we will roll back all
 	ctx := context.Background()
@@ -214,7 +220,7 @@ func (locker *Locker) PushSchedulerLock(nodes map[string]ProxySQLNode) bool {
 	}
 	for key, node := range nodes {
 		if node.Dns != "" {
-			sqlAction := strings.ReplaceAll(SQL.Dml_update_comment_proxy_servers,"?", node.Comment) + " where hostname='" + node.Ip + "' and port= " + strconv.Itoa(node.Port)
+			sqlAction := strings.ReplaceAll(SQL.Dml_update_comment_proxy_servers, "?", node.Comment) + " where hostname='" + node.Ip + "' and port= " + strconv.Itoa(node.Port)
 			_, err = tx.ExecContext(ctx, sqlAction)
 			if err != nil {
 				tx.Rollback()
@@ -243,20 +249,20 @@ func (locker *Locker) PushSchedulerLock(nodes map[string]ProxySQLNode) bool {
 		}
 
 	}
-	if Global.Performance {
-		Global.SetPerformanceObj("Execute SQL changes - ProxySQL cluster LOCK ("+ locker.ClusterLockId +")" , false,log.DebugLevel)
+	if global.Performance {
+		global.SetPerformanceObj("Execute SQL changes - ProxySQL cluster LOCK ("+locker.ClusterLockId+")", false, log.DebugLevel)
 	}
 
 	return true
 }
 
-func (locker *Locker)SetLockFile() bool {
-	if locker.FileLock ==""{
+func (locker *Locker) SetLockFile() bool {
+	if locker.FileLock == "" {
 		log.Error("Lock Filename is invalid (empty) ")
 		return false
 	}
 	fullFile := locker.FileLockPath + string(os.PathSeparator) + locker.FileLock
-	if _, err := os.Stat(fullFile); err == nil && !locker.isLooped{
+	if _, err := os.Stat(fullFile); err == nil && !locker.isLooped {
 		fmt.Printf("A lock file named: %s  already exists.\n If this is a refuse of a dirty execution remove it manually to have the check able to run\n", fullFile)
 		return false
 	} else {
@@ -284,7 +290,7 @@ func (locker *Locker)SetLockFile() bool {
 	return true
 }
 
-func (locker *Locker)RemoveLockFile() bool {
+func (locker *Locker) RemoveLockFile() bool {
 	e := os.Remove(locker.FileLockPath + string(os.PathSeparator) + locker.FileLock)
 	if e != nil {
 		log.Fatalf("Cannot remove lock file %s", e)

--- a/lib/DataObjects/dataObjects.go
+++ b/lib/DataObjects/dataObjects.go
@@ -1,4 +1,4 @@
-package DataObjects
+package dataobjects
 
 import (
 	"crypto/tls"
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"time"
 
-	"../Global"
+	global "../Global"
 	SQLPxc "../Sql/Pcx"
 	SQLProxy "../Sql/Proxy"
 	"github.com/go-sql-driver/mysql"
@@ -133,27 +133,27 @@ Methods
 /*
 Data cluster initialization method
 */
-func (cluster *DataCluster) init(config Global.Configuration, connectionProxy *sql.DB) bool {
+func (cluster *DataCluster) init(config *global.Configuration, connectionProxy *sql.DB) bool {
 
-	if Global.Performance {
-		Global.SetPerformanceObj("data_cluster_init", true, log.InfoLevel)
+	if global.Performance {
+		global.SetPerformanceObj("data_cluster_init", true, log.InfoLevel)
 	}
 	//set parameters from the config file
 	cluster.Debug = config.Global.Debug
-	cluster.ClusterIdentifier = config.Pxcluster.ClusterId
-	cluster.CheckTimeout = config.Pxcluster.CheckTimeOut
-	cluster.MainSegment = config.Pxcluster.MainSegment
-	cluster.ActiveFailover = config.Pxcluster.ActiveFailover
-	cluster.FailBack = config.Pxcluster.FailBack
+	cluster.ClusterIdentifier = config.PxcCluster.ClusterID
+	cluster.CheckTimeout = config.PxcCluster.CheckTimeOut
+	cluster.MainSegment = config.PxcCluster.MainSegment
+	cluster.ActiveFailover = config.PxcCluster.ActiveFailover
+	cluster.FailBack = config.PxcCluster.FailBack
 
 	//Enable SSL support
-	if config.Pxcluster.SslClient != "" && config.Pxcluster.SslKey != "" && config.Pxcluster.SslCa != "" {
+	if config.PxcCluster.SslClient != "" && config.PxcCluster.SslKey != "" && config.PxcCluster.SslCa != "" {
 		ssl := new(SslCertificates)
-		ssl.sslClient = config.Pxcluster.SslClient
-		ssl.sslKey = config.Pxcluster.SslKey
-		ssl.sslCa = config.Pxcluster.SslCa
-		if config.Pxcluster.SslcertificatePath != "" {
-			ssl.sslCertificatePath = config.Pxcluster.SslcertificatePath
+		ssl.sslClient = config.PxcCluster.SslClient
+		ssl.sslKey = config.PxcCluster.SslKey
+		ssl.sslCa = config.PxcCluster.SslCa
+		if config.PxcCluster.SslcertificatePath != "" {
+			ssl.sslCertificatePath = config.PxcCluster.SslcertificatePath
 		} else {
 			path, err := os.Getwd()
 			if err != nil {
@@ -198,8 +198,8 @@ func (cluster *DataCluster) init(config Global.Configuration, connectionProxy *s
 		}
 	}
 
-	if Global.Performance {
-		Global.SetPerformanceObj("data_cluster_init", false, log.InfoLevel)
+	if global.Performance {
+		global.SetPerformanceObj("data_cluster_init", false, log.InfoLevel)
 	}
 	return true
 }
@@ -208,7 +208,7 @@ func (cluster *DataCluster) init(config Global.Configuration, connectionProxy *s
 // We will use the Nodes list with all the IP:Port pair no matter what HG to check the nodes and then will assign the information to the relevant node collection
 // like Bkup(r/w) or Readers/Writers
 func (cluster *DataCluster) getNodesInfo() bool {
-	var waitingGroup Global.MyWaitGroup
+	var waitingGroup global.MyWaitGroup
 
 	//Before getting the information, we check if any node in the 8000 is gone lost and if so we try to add it back
 	cluster.NodesPxc.internal = cluster.checkMissingForNodes(cluster.NodesPxc.internal)
@@ -253,8 +253,8 @@ In prod is parallelized
 */
 func (cluster *DataCluster) loadNodes(connectionProxy *sql.DB) bool {
 	// get list of nodes from ProxySQL
-	if Global.Performance {
-		Global.SetPerformanceObj("loadNodes", true, log.InfoLevel)
+	if global.Performance {
+		global.SetPerformanceObj("loadNodes", true, log.InfoLevel)
 	}
 	var sb strings.Builder
 	sb.WriteString(strconv.Itoa(cluster.HgWriterId))
@@ -339,25 +339,25 @@ func (cluster *DataCluster) loadNodes(connectionProxy *sql.DB) bool {
 		}
 
 	}
-	if Global.Performance {
-		Global.SetPerformanceObj("loadNodes", false, log.InfoLevel)
+	if global.Performance {
+		global.SetPerformanceObj("loadNodes", false, log.InfoLevel)
 	}
 	return true
 }
 
 //load values from db disk in ProxySQL
-func (cluster *DataCluster) getParametersFromProxySQL(config Global.Configuration) bool {
+func (cluster *DataCluster) getParametersFromProxySQL(config *global.Configuration) bool {
 
-	cluster.ClusterIdentifier = config.Pxcluster.ClusterId
-	cluster.HgWriterId = config.Pxcluster.HgW
-	cluster.HgReaderId = config.Pxcluster.HgR
-	cluster.BakcupHgWriterId = config.Pxcluster.BckHgW
-	cluster.BackupHgReaderId = config.Pxcluster.BckHgR
-	cluster.SinglePrimary = config.Pxcluster.SinglePrimary
-	cluster.MaxNumWriters = config.Pxcluster.MaxNumWriters
-	cluster.WriterIsReader = config.Pxcluster.WriterIsAlsoReader
-	cluster.RetryUp = config.Pxcluster.RetryUp
-	cluster.RetryDown = config.Pxcluster.RetryDown
+	cluster.ClusterIdentifier = config.PxcCluster.ClusterID
+	cluster.HgWriterId = config.PxcCluster.HgW
+	cluster.HgReaderId = config.PxcCluster.HgR
+	cluster.BakcupHgWriterId = config.PxcCluster.BckHgW
+	cluster.BackupHgReaderId = config.PxcCluster.BckHgR
+	cluster.SinglePrimary = config.PxcCluster.SinglePrimary
+	cluster.MaxNumWriters = config.PxcCluster.MaxNumWriters
+	cluster.WriterIsReader = config.PxcCluster.WriterIsAlsoReader
+	cluster.RetryUp = config.PxcCluster.RetryUp
+	cluster.RetryDown = config.PxcCluster.RetryDown
 	//)
 	if log.GetLevel() == log.DebugLevel {
 		log.Debug("Cluster arguments ", " clusterid=", cluster.ClusterIdentifier,
@@ -498,8 +498,8 @@ The actionList is the object returning the list of nodes that require modificati
 Any modification at their status in ProxySQL is done by the ProxySQLNode object
 */
 func (cluster *DataCluster) GetActionList() map[string]DataNodePxc {
-	if Global.Performance {
-		Global.SetPerformanceObj("Get Action Map (DataCluster)", true, log.DebugLevel)
+	if global.Performance {
+		global.SetPerformanceObj("Get Action Map (DataCluster)", true, log.DebugLevel)
 	}
 	/*
 		NOTES:
@@ -528,8 +528,8 @@ func (cluster *DataCluster) GetActionList() map[string]DataNodePxc {
 	if !cluster.checkFailoverIfFound() {
 		log.Error("Error electing Node for fail-over")
 	}
-	if Global.Performance {
-		Global.SetPerformanceObj("Get Action Map (DataCluster)", false, log.DebugLevel)
+	if global.Performance {
+		global.SetPerformanceObj("Get Action Map (DataCluster)", false, log.DebugLevel)
 	}
 
 	//At this point we should be able to do actions in consistent way
@@ -1084,8 +1084,8 @@ func (cluster *DataCluster) processUpActionMap() {
 		hg := key[0:strings.Index(key, "_")]
 		ip := key[strings.Index(key, "_")+1 : strings.Index(key, ":")]
 		port := key[strings.Index(key, ":")+1:]
-		hgI = Global.ToInt(hg)
-		portI = Global.ToInt(port)
+		hgI = global.ToInt(hg)
+		portI = global.ToInt(port)
 		// We process only WRITERS
 		if currentHg.Type == "W" || currentHg.Type == "WREC" {
 			if node.DataNodeBase.ReturnActionCategory(node.DataNodeBase.ActionType) == "UP" ||
@@ -1195,8 +1195,8 @@ func (cluster *DataCluster) processDownActionMap() {
 		hg := key[0:strings.Index(key, "_")]
 		ip := key[strings.Index(key, "_")+1 : strings.Index(key, ":")]
 		port := key[strings.Index(key, ":")+1:]
-		hgI = Global.ToInt(hg)
-		portI = Global.ToInt(port)
+		hgI = global.ToInt(hg)
+		portI = global.ToInt(port)
 
 		// We process only WRITERS and check for nodes marked in EvalNodes as DOWN
 		if currentHg.Type == "W" || currentHg.Type == "WREC" {
@@ -1364,8 +1364,8 @@ func (cluster *DataCluster) pushNewNode(node DataNodePxc) bool {
 return true if successful in any other case false
 */
 func (node *DataNode) GetConnection() bool {
-	if Global.Performance {
-		Global.SetPerformanceObj("node_connection_"+node.Dns, true, log.DebugLevel)
+	if global.Performance {
+		global.SetPerformanceObj("node_connection_"+node.Dns, true, log.DebugLevel)
 	}
 	//dns := node.User + ":" + node.Password + "@tcp(" + node.Dns + ":"+ strconv.Itoa(node.Port) +")/admin" //
 	//if log.GetLevel() == log.DebugLevel {log.Debug(dns)}
@@ -1404,9 +1404,9 @@ func (node *DataNode) GetConnection() bool {
 		if node.Ssl == nil {
 			attributes = attributes + "&tls=skip-verify"
 		} else if node.Ssl.sslCertificatePath != "" {
-			ca := node.Ssl.sslCertificatePath + Global.Separator + node.Ssl.sslCa
-			client := node.Ssl.sslCertificatePath + Global.Separator + node.Ssl.sslClient
-			key := node.Ssl.sslCertificatePath + Global.Separator + node.Ssl.sslKey
+			ca := node.Ssl.sslCertificatePath + global.Separator + node.Ssl.sslCa
+			client := node.Ssl.sslCertificatePath + global.Separator + node.Ssl.sslClient
+			key := node.Ssl.sslCertificatePath + global.Separator + node.Ssl.sslKey
 
 			rootCertPool := x509.NewCertPool()
 			pem, err := ioutil.ReadFile(ca)
@@ -1450,8 +1450,8 @@ func (node *DataNode) GetConnection() bool {
 	}
 	node.NodeTCPDown = false
 
-	if Global.Performance {
-		Global.SetPerformanceObj("node_connection_"+node.Dns, false, log.DebugLevel)
+	if global.Performance {
+		global.SetPerformanceObj("node_connection_"+node.Dns, false, log.DebugLevel)
 	}
 	return true
 }

--- a/lib/DataObjects/pxcObjects.go
+++ b/lib/DataObjects/pxcObjects.go
@@ -1,11 +1,12 @@
-package DataObjects
+package dataobjects
 
 import (
-	"../Global"
-	SQLPxc "../Sql/Pcx"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"strings"
+
+	global "../Global"
+	SQLPxc "../Sql/Pcx"
+	log "github.com/sirupsen/logrus"
 )
 
 type DataNodePxc struct {
@@ -48,9 +49,9 @@ func (node *DataNodePxc) getPxcView(dml string) PxcClusterView {
 }
 
 //We parallelize the information retrieval using goroutine
-func (node DataNodePxc) getInfo(wg *Global.MyWaitGroup, cluster *DataCluster) int {
-	if Global.Performance {
-		Global.SetPerformanceObj(fmt.Sprintf("Get info for node %s",node.DataNodeBase.Dns), true,log.DebugLevel)
+func (node DataNodePxc) getInfo(wg *global.MyWaitGroup, cluster *DataCluster) int {
+	if global.Performance {
+		global.SetPerformanceObj(fmt.Sprintf("Get info for node %s", node.DataNodeBase.Dns), true, log.DebugLevel)
 	}
 	// Get the connection
 	node.DataNodeBase.GetConnection()
@@ -70,8 +71,8 @@ func (node DataNodePxc) getInfo(wg *Global.MyWaitGroup, cluster *DataCluster) in
 
 		//set the specific monitoring parameters
 		node.setParameters()
-		if Global.Performance {
-			Global.SetPerformanceObj(fmt.Sprintf("Get info for node %s",node.DataNodeBase.Dns), false,log.DebugLevel)
+		if global.Performance {
+			global.SetPerformanceObj(fmt.Sprintf("Get info for node %s", node.DataNodeBase.Dns), false, log.DebugLevel)
 		}
 	} else {
 		node.DataNodeBase.Processed = false
@@ -93,22 +94,22 @@ func (node DataNodePxc) getInfo(wg *Global.MyWaitGroup, cluster *DataCluster) in
 func (node *DataNodePxc) setParameters() {
 	node.WsrepLocalIndex = node.PxcView.LocalIndex
 	node.PxcMaintMode = node.DataNodeBase.Variables["pxc_maint_mode"]
-	node.WsrepConnected = Global.ToBool(node.DataNodeBase.Status["wsrep_connected"], "ON")
-	node.WsrepDesinccount = Global.ToInt(node.DataNodeBase.Status["wsrep_desync_count"])
-	node.WsrepDonorrejectqueries = Global.ToBool(node.DataNodeBase.Variables["wsrep_sst_donor_rejects_queries"], "ON")
+	node.WsrepConnected = global.ToBool(node.DataNodeBase.Status["wsrep_connected"], "ON")
+	node.WsrepDesinccount = global.ToInt(node.DataNodeBase.Status["wsrep_desync_count"])
+	node.WsrepDonorrejectqueries = global.ToBool(node.DataNodeBase.Variables["wsrep_sst_donor_rejects_queries"], "ON")
 	node.WsrepGcommUuid = node.DataNodeBase.Status["wsrep_gcomm_uuid"]
-	node.WsrepProvider = Global.FromStringToMAp(node.DataNodeBase.Variables["wsrep_provider_options"], ";")
-	node.HasPrimaryState = Global.ToBool(node.DataNodeBase.Status["wsrep_cluster_status"], "Primary")
+	node.WsrepProvider = global.FromStringToMAp(node.DataNodeBase.Variables["wsrep_provider_options"], ";")
+	node.HasPrimaryState = global.ToBool(node.DataNodeBase.Status["wsrep_cluster_status"], "Primary")
 
 	node.WsrepClusterName = node.DataNodeBase.Variables["wsrep_cluster_name"]
 	node.WsrepClusterStatus = node.DataNodeBase.Status["wsrep_cluster_status"]
 	node.WsrepNodeName = node.DataNodeBase.Variables["wsrep_node_name"]
-	node.WsrepClusterSize = Global.ToInt(node.DataNodeBase.Status["wsrep_cluster_size"])
-	node.WsrepPcWeight = Global.ToInt(node.WsrepProvider["pc.weight"])
-	node.WsrepReady = Global.ToBool(node.DataNodeBase.Status["wsrep_ready"], "on")
-	node.WsrepRejectqueries = !Global.ToBool(node.DataNodeBase.Variables["wsrep_reject_queries"], "none")
-	node.WsrepSegment = Global.ToInt(node.WsrepProvider["gmcast.segment"])
-	node.WsrepStatus = Global.ToInt(node.DataNodeBase.Status["wsrep_local_state"])
-	node.DataNodeBase.ReadOnly = Global.ToBool(node.DataNodeBase.Variables["read_only"], "on")
+	node.WsrepClusterSize = global.ToInt(node.DataNodeBase.Status["wsrep_cluster_size"])
+	node.WsrepPcWeight = global.ToInt(node.WsrepProvider["pc.weight"])
+	node.WsrepReady = global.ToBool(node.DataNodeBase.Status["wsrep_ready"], "on")
+	node.WsrepRejectqueries = !global.ToBool(node.DataNodeBase.Variables["wsrep_reject_queries"], "none")
+	node.WsrepSegment = global.ToInt(node.WsrepProvider["gmcast.segment"])
+	node.WsrepStatus = global.ToInt(node.DataNodeBase.Status["wsrep_local_state"])
+	node.DataNodeBase.ReadOnly = global.ToBool(node.DataNodeBase.Variables["read_only"], "on")
 
 }

--- a/lib/Global/configuration_test.go
+++ b/lib/Global/configuration_test.go
@@ -1,0 +1,100 @@
+package global_test
+
+import (
+	"testing"
+
+	global "../Global"
+)
+
+var gConfig = global.Configuration{
+	ProxySQL: global.ProxySQLConfig{
+		Port: 1000,
+	},
+	PxcCluster: global.PxcClusterConfig{
+		SinglePrimary: true,
+		Host:          "defaultHost",
+		MaxNumWriters: 1,
+		HgW:           1,
+		BckHgW:        8001,
+		HgR:           2,
+		BckHgR:        8002,
+	},
+	Global: global.SchedulerConfig{
+		Debug: true,
+	},
+}
+
+func TestGetConfigProviderReturnsNull(t *testing.T) {
+	config := global.GetConfig(func(string) *global.Configuration { return nil }, "test")
+
+	if config != nil {
+		t.Errorf("No config expected when error")
+	}
+}
+
+func TestGetConfigReturnsWhatProviderProvides(t *testing.T) {
+	config := global.GetConfig(func(string) *global.Configuration { return &gConfig }, "test")
+	if config == nil {
+		t.Errorf("Expected config returned from GetConfig()")
+	}
+
+	if config.ProxySQL.Port != 1000 ||
+		config.PxcCluster.SinglePrimary != true ||
+		config.PxcCluster.Host != "defaultHost" ||
+		config.Global.Debug != true {
+		t.Errorf("Configuration mismatch")
+	}
+}
+
+func TestGetConfigSinglePrimaryVsMaxWritersSanityCheck(t *testing.T) {
+	config := global.GetConfig(func(string) *global.Configuration {
+		c := gConfig
+		c.PxcCluster.MaxNumWriters = 2
+		c.PxcCluster.SinglePrimary = true
+		return &c
+	}, "test")
+
+	if config != nil {
+		t.Errorf("No config expected when error")
+	}
+}
+
+func TestGetConfigNegativeParamValue(t *testing.T) {
+	config := global.GetConfig(func(string) *global.Configuration {
+		c := gConfig
+		c.PxcCluster.MaxNumWriters = -8
+		c.PxcCluster.SinglePrimary = true
+
+		return &c
+	}, "test")
+
+	if config != nil {
+		t.Errorf("No config expected when error")
+	}
+}
+
+func TestGetConfigWriteIsReaderInvalidValue(t *testing.T) {
+	config := global.GetConfig(func(string) *global.Configuration {
+		c := gConfig
+		c.PxcCluster.WriterIsAlsoReader = 7
+
+		return &c
+	}, "test")
+
+	if config != nil {
+		t.Errorf("No config expected when error")
+	}
+}
+
+func TestGetConfigActiveFailoverInvalidValue(t *testing.T) {
+	config := global.GetConfig(func(string) *global.Configuration {
+		c := gConfig
+		c.PxcCluster.ActiveFailover = 4
+
+		return &c
+	}, "test")
+
+	if config != nil {
+		t.Errorf("No config expected when error")
+	}
+}

--- a/lib/Global/help.go
+++ b/lib/Global/help.go
@@ -1,22 +1,40 @@
-package Global
+package global
 
-import "fmt"
+import (
+	"fmt"
+	"sync"
+)
 
+// Help is the interface for getting help strings
+type Help interface {
+	PrintLicense()
+	HelpText() string
+}
 
-type HelpText struct{
-	inParams [2]string
-	license string
+// GetHelp returns singleton Help interface
+func GetHelp() Help {
+	once.Do(func() {
+		ht = &help{}
+	})
+	return ht
+}
+
+var (
+	ht   *help
+	once sync.Once
+)
+
+type help struct {
+	license   string
 	helpShort string
 }
-func (help *HelpText) Init(){
-	help.inParams = [2]string{"configfile","configPath"}
-}
-func (help *HelpText)PrintLicense(){
-		fmt.Println(help.GetHelpText())
+
+func (help *help) PrintLicense() {
+	fmt.Println(help.HelpText())
 }
 
-func (help *HelpText)GetHelpText() string{
- helpText := `pxcScheduler
+func (help *help) HelpText() string {
+	helpText := `pxcScheduler
 
 Parameters for the executable --configfile <file name> --configpath <full path> --help
 
@@ -91,16 +109,16 @@ We will need to :
 	INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,max_connections,comment) VALUES ('192.168.4.22',101,3306,998,2000,'last reader');
 	INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,max_connections,comment) VALUES ('192.168.4.23',101,3306,1000,2000,'reader1');    
 	INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,max_connections,comment) VALUES ('192.168.4.233',101,3306,1000,2000,'reader2');        
-	
+
 	INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,max_connections,comment) VALUES ('192.168.4.22',8100,3306,1000,2000,'Failover server preferred');
 	INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,max_connections,comment) VALUES ('192.168.4.23',8100,3306,999,2000,'Second preferred');    
 	INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,max_connections,comment) VALUES ('192.168.4.233',8100,3306,998,2000,'Thirdh and last in the list');      
-	
+
 	INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,max_connections,comment) VALUES ('192.168.4.22',8101,3306,998,2000,'Failover server preferred');
 	INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,max_connections,comment) VALUES ('192.168.4.23',8101,3306,999,2000,'Second preferred');    
 	INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,max_connections,comment) VALUES ('192.168.4.233',8101,3306,1000,2000,'Thirdh and last in the list');      
 
 	LOAD MYSQL SERVERS TO RUNTIME; SAVE MYSQL SERVERS TO DISK;
 `
-return helpText
+	return helpText
 }

--- a/lib/Global/log.go
+++ b/lib/Global/log.go
@@ -1,0 +1,122 @@
+package global
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// InitLog initializs logging according to passed configuration
+func InitLog(config *Configuration) bool {
+
+	// set a consistent output for the log no matter if file or stdout
+	formatter := logFormat{}
+	formatter.TimestampFormat = "2006-01-02 15:04:05"
+	log.SetFormatter(&formatter)
+
+	if strings.ToLower(config.Global.LogTarget) == "stdout" {
+		log.SetOutput(os.Stdout)
+	} else if strings.ToLower(config.Global.LogTarget) == "file" &&
+		config.Global.LogFile != "" {
+		// try to initialize the log on file if it fails it will redirect to stdout
+		file, err := os.OpenFile(config.Global.LogFile, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0666)
+		if err == nil {
+			log.SetOutput(file)
+		} else {
+			log.Error("Error logging to file ", err.Error())
+			return false
+		}
+	}
+
+	// set log severity level
+	switch level := strings.ToLower(config.Global.LogLevel); level {
+	case "debug":
+		log.SetLevel(log.DebugLevel)
+	case "info":
+		log.SetLevel(log.InfoLevel)
+	case "warning":
+		log.SetLevel(log.WarnLevel)
+	case "error":
+		log.SetLevel(log.ErrorLevel)
+	default:
+		log.SetLevel(log.ErrorLevel)
+	}
+
+	if log.GetLevel() == log.DebugLevel {
+		log.Debug("Testing the log")
+		log.Info("Testing the log")
+		log.Warning("Testing the log")
+		log.Error("testing log errors")
+		log.SetLevel(log.DebugLevel)
+		log.Debug("Log initialized")
+	}
+	return true
+}
+
+type logFormat struct {
+	TimestampFormat string
+}
+
+func (f *logFormat) Format(entry *log.Entry) ([]byte, error) {
+	var b *bytes.Buffer
+
+	if entry.Buffer != nil {
+		b = entry.Buffer
+	} else {
+		b = &bytes.Buffer{}
+	}
+
+	b.WriteString("\x1b[" + strconv.Itoa(getColorByLevel(entry.Level)) + "m")
+	b.WriteByte('[')
+	b.WriteString(strings.ToUpper(entry.Level.String()))
+	b.WriteString("]")
+	b.WriteString("\x1b[0m")
+	b.WriteByte(':')
+	b.WriteString(entry.Time.Format(f.TimestampFormat))
+
+	if entry.Message != "" {
+		b.WriteString(" - ")
+		b.WriteString(entry.Message)
+	}
+
+	if len(entry.Data) > 0 {
+		b.WriteString(" || ")
+	}
+	for key, value := range entry.Data {
+		b.WriteString(key)
+		b.WriteByte('=')
+		b.WriteByte('{')
+		fmt.Fprint(b, value)
+		b.WriteString("}, ")
+	}
+
+	b.WriteByte('\n')
+	return b.Bytes(), nil
+}
+
+const (
+	colorRed    = 31
+	colorYellow = 33
+	colorBlue   = 36
+	colorGray   = 34
+	paniclevel  = 35
+)
+
+func getColorByLevel(level log.Level) int {
+	switch level {
+	case log.DebugLevel:
+		return colorGray
+	case log.WarnLevel:
+		return colorYellow
+	case log.ErrorLevel:
+		return colorRed
+	case log.PanicLevel, log.FatalLevel:
+		return paniclevel
+	default:
+		return colorBlue
+	}
+}

--- a/lib/Global/utils.go
+++ b/lib/Global/utils.go
@@ -1,10 +1,7 @@
-package Global
+package global
 
 import (
 	"fmt"
-	log "github.com/sirupsen/logrus"
-	"golang.org/x/text/language"
-	"golang.org/x/text/message"
 	"os"
 	"reflect"
 	"runtime"
@@ -12,6 +9,10 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/text/language"
+	"golang.org/x/text/message"
 )
 
 type MyWaitGroup struct {
@@ -132,6 +133,7 @@ func ReflectStructField(Iface interface{}, FieldName string) error {
 	}
 	return nil
 }
+
 //----------------------
 /* =====================
 STATS
@@ -181,8 +183,6 @@ func (rm *StatSyncInfo) ExposeMap() map[string][2]int64 {
 	return rm.internal
 }
 
-
-
 //====================================================
 
 // Struct
@@ -193,7 +193,7 @@ type OrderedPerfMap struct {
 }
 
 // Constructor
-func NewOrderedMap () *OrderedPerfMap {
+func NewOrderedMap() *OrderedPerfMap {
 	return &OrderedPerfMap{
 		store: map[string]PerfObject{},
 		keys:  []string{},
@@ -271,6 +271,7 @@ func CheckIfPathExists(path string) bool {
 	}
 	return false
 }
+
 //=======
 
 func caseInsenstiveFieldByName(v reflect.Value, name string) reflect.Value {
@@ -278,13 +279,12 @@ func caseInsenstiveFieldByName(v reflect.Value, name string) reflect.Value {
 	return v.FieldByNameFunc(func(n string) bool { return strings.ToLower(n) == name })
 }
 
-
 //====================================
 
 //stats structure
 type PerfObject struct {
-	Name string
-	Time [2]int64
+	Name     string
+	Time     [2]int64
 	LogLevel log.Level
 }
 
@@ -305,16 +305,16 @@ func SetPerformanceValue(key string, start bool) {
 	PerformanceMap.Store(key, valStat) //  ExposeMap()[key] = valStat
 }
 
-func SetPerformanceObj(key string, start bool,logLevel log.Level) {
+func SetPerformanceObj(key string, start bool, logLevel log.Level) {
 	var perfObj PerfObject
 	valStat := [2]int64{}
 
-	if val, exists := PerformanceMapOrdered.Get(key); !exists{
-		perfObj  = val
+	if val, exists := PerformanceMapOrdered.Get(key); !exists {
+		perfObj = val
 		perfObj.LogLevel = logLevel
 		perfObj.Name = key
 		valStat = [2]int64{0, 0}
-	}else{
+	} else {
 		perfObj = val
 		valStat = perfObj.Time
 	}
@@ -354,5 +354,3 @@ func ReportPerformance() {
 		}
 	}
 }
-
-

--- a/lib/Sql/Pcx/sqlobjects.go
+++ b/lib/Sql/Pcx/sqlobjects.go
@@ -1,16 +1,13 @@
-package Pcx
+package pxc
 
-
-const(
-/*
-Retrieve main information from Data nodes
- */
+const (
+	/*
+	   Retrieve main information from Data nodes
+	*/
 
 	Dml_get_variables = "select * from performance_schema.global_variables"
-	Dml_get_status = "select * from performance_schema.global_status"
-	Dml_get_pxc_view ="select * from performance_schema.pxc_cluster_view where UUID = '?'"
+	Dml_get_status    = "select * from performance_schema.global_status"
+	Dml_get_pxc_view  = "select * from performance_schema.pxc_cluster_view where UUID = '?'"
 
 	Dml_get_ssl_status = "SHOW SESSION STATUS LIKE 'Ssl_cipher'"
-
-
 )

--- a/lib/Sql/Proxy/sqlobjects.go
+++ b/lib/Sql/Proxy/sqlobjects.go
@@ -1,22 +1,21 @@
-package Proxy
+package proxy
 
 /*
 Class dealing with ALL SQL commands.
 No SQL should be hardcoded in the any other class
- */
+*/
 
-
-const(
+const (
 	//get MySQL nodes to process based on the HG
 	//+--------------+---------------+------+-----------+--------------+---------+-------------+-----------------+---------------------+---------+----------------+-------------------------------------------------------------|---------+
 	//| hostgroup_id | hostname      | port | gtid_port | status       | weight  | compression | max_connections | max_replication_lag | use_ssl | max_latency_ms | comment                                                     |ConnUsed|
 	Dml_Select_mysql_nodes = " select b.*, c.ConnUsed from stats_mysql_connection_pool c left JOIN runtime_mysql_servers b ON  c.hostgroup=b.hostgroup_id and c.srv_host=b.hostname and c.srv_port = b.port where hostgroup_id in (?)  order by hostgroup,srv_host desc;"
 
-      //get Variables
-    Dml_show_variables="SHOW GLOBAL VARIABLES"
+	//get Variables
+	Dml_show_variables = "SHOW GLOBAL VARIABLES"
 
-    Dml_select_proxy_servers = "select weight,hostname,port,comment from runtime_proxysql_servers order by weight desc"
+	Dml_select_proxy_servers = "select weight,hostname,port,comment from runtime_proxysql_servers order by weight desc"
 
-	Dml_delete_proxy_servers = "delete from proxysql_servers where hostname = '?1' and port = ?2 "
+	Dml_delete_proxy_servers         = "delete from proxysql_servers where hostname = '?1' and port = ?2 "
 	Dml_update_comment_proxy_servers = "update proxysql_servers set comment ='?'"
 )

--- a/test/tests_definition.txt
+++ b/test/tests_definition.txt
@@ -1,4 +1,4 @@
-Proxysql scheduler tests
+ProxySQL scheduler tests
 
 Scenario:
 =======================================


### PR DESCRIPTION
This is based on work done in #13 (for better test coverage), so it contains everything from #13 plus:

1. Help extracted to separate file. It is singleton object.
2. Package names changed according to golint suggestions (lowercase)
DataObjects -> dataobjects
Global -> global
Proxy -> proxy
Pxc -> pxc
3. Configuration structures exported from package and named properly
(golint)
4. Configuration parsing refactored to allow unit tests. Sanity check
moved inside as it is not necessary to see it from main() level
5. Unit tests for configuration added.
6. Fixed several configuration validation bugs (added more sanitization)
7. Config structure passed by pointer to avoid unnecessary copying of
this struct
8. proxy_scheduler.go_copy file removed
9. Autoformatting according to golint rules
10. Locker allocated on stack