### PR TITLE
renaming the project

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/pxc_scheduler.iml" filepath="$PROJECT_DIR$/.idea/pxc_scheduler.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/pxc_scheduler_handler.iml" filepath="$PROJECT_DIR$/.idea/pxc_scheduler_handler.iml" />
     </modules>
   </component>
 </project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,12 +2,9 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/src/github.com/BurntSushi/toml" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/src/github.com/davecgh/go-spew" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/src/github.com/jmoiron/sqlx" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/src/github.com/lib/pq" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/src/github.com/mattn/go-sqlite3" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/src/github.com/pmezard/go-difflib" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/src/github.com/sirupsen/logrus" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/src/github.com/stretchr/testify" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/src/github.com/t-tomalak/logrus-easy-formatter" vcs="Git" />

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ This project follows the GO layout standards as for https://github.com/golang-st
 
 Once you have GO installed and running (version 1.16 is recommended. Version 1.15.8 is still supported)
 
-Clone from github: `git clone https://github.com/Tusamarco/proxysql_scheduler.git`
+Clone from github: `git clone https://github.com/Tusamarco/pxc_scheduler_handler.git`
 
 Install the needed library within go:
 ```bash

--- a/config/config.toml
+++ b/config/config.toml
@@ -27,14 +27,14 @@ host = "127.0.0.1"
 user = "<valid user to connect from real ip as for proxysql_server table>"
 password = "<password>"
 clustered = false
-lockfilepath ="/var/run/proxysql_scheduler"
+lockfilepath ="/var/run/pxc_scheduler_handler"
 respectManualOfflineSoft=false
 
 [global]
 debug = true
 logLevel = "info"
 logTarget = "stdout" #stdout | file
-logFile = "/var/log/proxysql_scheduler/pscheduler.log"
+logFile = "/var/log/pxc_scheduler_handler/pscheduler.log"
 daemonize = false
 daemonInterval = 2000
 performance = true

--- a/mtr/README.md
+++ b/mtr/README.md
@@ -1,9 +1,9 @@
-# proxysql_scheduler automated functional tests
+# pxc_scheduler_handler automated functional tests
 
 ## Background
 This directory contains tests that can be executed by standard PXC MTR framework.
-We found that automating proxysql_scheduler tests is needed to make them repeatable and much faster to execute. Standard MTR famework which allows interactions with mysql daemons, clients and arbitrary software is used to achieve this goal.
-The idea is to not modify the framework already existing in PXC repository. We provide dedicated MTR suite for proxysql_scheduler testing together with several convenience include files for common tasks.
+We found that automating pxc_scheduler_handler tests is needed to make them repeatable and much faster to execute. Standard MTR famework which allows interactions with mysql daemons, clients and arbitrary software is used to achieve this goal.
+The idea is to not modify the framework already existing in PXC repository. We provide dedicated MTR suite for pxc_scheduler_handler testing together with several convenience include files for common tasks.
 
 ## How to use
 1. Install and start ProxySQL service.
@@ -11,22 +11,22 @@ Admin credentials: admin/admin
 Admin port: 6032
 Connection port: 6033
 2. Next step is to have PXC binaries,  tests and MTR framework. They can be installed from PXC package or build from sources.
-3. Clone `proxysql_scheduler` project
-4. Inside PXC mtr test suites directory create link to the `mtr/proxysql` directory from `proxysql_scheduler`. 
+3. Clone `pxc_scheduler_handler` project
+4. Inside PXC mtr test suites directory create link to the `mtr/proxysql` directory from `pxc_scheduler_handler`. 
 The link should look like:
 ```
 $ pwd
 /repo/percona-xtradb-cluster/mysql-test/suite
 $ ls -l proxysql
-proxysql -> /repo/proxysql_scheduler/mtr/proxysql
+proxysql -> /repo/pxc_scheduler_handler/mtr/proxysql
 ```
-5. Environment variable PROXYSQL_SCHEDULER_SCRIPT pointing to `pxc_scheduler_handler` binary:
+5. Environment variable PXC_SCHEDULER_HANDLER_SCRIPT pointing to `pxc_scheduler_handler` binary:
 ```
-$export PROXYSQL_SCHEDULER_SCRIPT=/path/to/proxysql_scheduler
+$export PXC_SCHEDULER_HANDLER_SCRIPT=/path/to/pxc_scheduler_handler/<binary>
 ```
-6.Environment variable PROXYSQL_SCHEDULER_CONFIG_DIR pointing to the directory where proxy_scheduler config files used by tests are located.
+6.Environment variable PXC_SCHEDULER_HANDLER_CONFIG_DIR pointing to the directory where pxc_scheduler_handler config files used by tests are located.
 ```
-export PROXYSQL_SCHEDULER_CONFIG_DIR=/repo/percona-xtradb-cluster/mysql-test/suite/proxysql/config
+export PXC_SCHEDULER_HANDLER_CONFIG_DIR=/repo/percona-xtradb-cluster/mysql-test/suite/proxysql/config
 ```
 7. Execute mtr tests
 ```

--- a/mtr/proxysql/include/common_proxysql_init.inc
+++ b/mtr/proxysql/include/common_proxysql_init.inc
@@ -14,43 +14,43 @@ UPDATE global_variables SET Variable_Value='utf8' WHERE Variable_name='mysql-def
 --enable_query_log
 
 #
-# Setup variable 'proxysql_scheduler_script' containing scheduler script path
+# Setup variable 'pxc_scheduler_handler_script' containing scheduler script path
 #
---let _PROXYSQL_SCHEDULER_VAR_IMPORT_FILE = $MYSQL_TMP_DIR/proxysql_scheduler_var_import
+--let _PXC_SCHEDULER_HANDLER_VAR_IMPORT_FILE = $MYSQL_TMP_DIR/pxc_scheduler_handler_var_import
 --perl
   use strict;
-  my $out_file = $ENV{'_PROXYSQL_SCHEDULER_VAR_IMPORT_FILE'} or die "_PROXYSQL_SCHEDULER_VAR_IMPORT_FILE is not set";
+  my $out_file = $ENV{'_PXC_SCHEDULER_HANDLER_VAR_IMPORT_FILE'} or die "_PXC_SCHEDULER_HANDLER_VAR_IMPORT_FILE is not set";
   open(OUT_FILE, '>', $out_file) or die("Unable to open out file for writing: $!\n");
-  print OUT_FILE "--let \$proxysql_scheduler_script=$ENV{'PROXYSQL_SCHEDULER_SCRIPT'}\n";
+  print OUT_FILE "--let \$pxc_scheduler_handler_script=$ENV{'PXC_SCHEDULER_HANDLER_SCRIPT'}\n";
   close(OUT_FILE);
 EOF
---source $_PROXYSQL_SCHEDULER_VAR_IMPORT_FILE
---remove_file $_PROXYSQL_SCHEDULER_VAR_IMPORT_FILE
+--source $_PXC_SCHEDULER_HANDLER_VAR_IMPORT_FILE
+--remove_file $_PXC_SCHEDULER_HANDLER_VAR_IMPORT_FILE
 
-if (!$proxysql_scheduler_script) {
-  --die "ProxySQL scheduler script not specified. Set env variable PROXYSQL_SCHEDULER_SCRIPT and restart the test" 
+if (!$pxc_scheduler_handler_script) {
+  --die "ProxySQL scheduler script not specified. Set env variable PXC_SCHEDULER_HANDLER_SCRIPT and restart the test"
 }
---file_exists $proxysql_scheduler_script
+--file_exists $pxc_scheduler_handler_script
 
 
 #
 # Temporary solution (we need command line parameters for scheduler script)
 #
 #
-# Setup variable 'proxysql_scheduler_config_dir' containing scheduler script config files
+# Setup variable 'pxc_scheduler_handler_config_dir' containing scheduler script config files
 #
---let _PROXYSQL_SCHEDULER_VAR_IMPORT_FILE = $MYSQL_TMP_DIR/proxysql_scheduler_var_import
+--let _PXC_SCHEDULER_HANDLER_VAR_IMPORT_FILE = $MYSQL_TMP_DIR/pxc_scheduler_handler_var_import
 --perl
   use strict;
-  my $out_file = $ENV{'_PROXYSQL_SCHEDULER_VAR_IMPORT_FILE'} or die "_PROXYSQL_SCHEDULER_VAR_IMPORT_FILE is not set";
+  my $out_file = $ENV{'_PXC_SCHEDULER_HANDLER_VAR_IMPORT_FILE'} or die "_PXC_SCHEDULER_HANDLER_VAR_IMPORT_FILE is not set";
   open(OUT_FILE, '>', $out_file) or die("Unable to open out file for writing: $!\n");
-  print OUT_FILE "--let \$proxysql_scheduler_config_dir=$ENV{'PROXYSQL_SCHEDULER_CONFIG_DIR'}\n";
+  print OUT_FILE "--let \$pxc_scheduler_handler_config_dir=$ENV{'PXC_SCHEDULER_HANDLER_CONFIG_DIR'}\n";
   close(OUT_FILE);
 EOF
---source $_PROXYSQL_SCHEDULER_VAR_IMPORT_FILE
---remove_file $_PROXYSQL_SCHEDULER_VAR_IMPORT_FILE
+--source $_PXC_SCHEDULER_HANDLER_VAR_IMPORT_FILE
+--remove_file $_PXC_SCHEDULER_HANDLER_VAR_IMPORT_FILE
 
-if (!$proxysql_scheduler_config_dir) {
-  --die "ProxySQL scheduler script not specified. Set env variable PROXYSQL_SCHEDULER_CONFIG_DIR and restart the test" 
+if (!$pxc_scheduler_handler_config_dir) {
+  --die "ProxySQL scheduler script not specified. Set env variable PXC_SCHEDULER_HANDLER_CONFIG_DIR and restart the test"
 }
 

--- a/mtr/proxysql/t/1w3r2bw_2actions.inc
+++ b/mtr/proxysql/t/1w3r2bw_2actions.inc
@@ -4,7 +4,7 @@
 #  node_1: writer/reader/backup writer weight 3
 #  node_2: reader/backup writer weight 2
 #  node_3: reader/backup writer weight 1
-# 3. Setup ProxySQL scheduler with config passed in $proxysql_scheduler_config
+# 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config
 # 4. Connect to $action_1_node and perform $action_1
 # 5. Validate ProxySQL configuration
 # 6. Connect to $action_2_node and perform $action_2
@@ -20,7 +20,7 @@
 --source ../include/common_pxc_init.inc
 
 # Check if ProxySQL scheduler config exists
---file_exists $proxysql_scheduler_config_dir/$proxysql_scheduler_config
+--file_exists $pxc_scheduler_handler_config_dir/$pxc_scheduler_handler_config
 
 #
 # ARRANGE
@@ -67,11 +67,11 @@
 #--let $scheduler_script=/home/kamil/repo/pxc/8.0/install/proxysql/galera_check.pl
 
 # The following line works with Perl
-# --replace_result $proxysql_scheduler_script SCHEDULER_SCRIPT $MYSQL_TMP_DIR MYSQL_TMP_DIR
-# --eval INSERT INTO scheduler (id,active,interval_ms,filename,arg1) values (10,1,3000,"$proxysql_scheduler_script","-u=admin -p=admin -h=127.0.0.1 -H=$wHG:W,$rHG:R -P=6032 --debug=1 --active_failover=1 --retry_down=2 --writer_is_also_reader=0 --log=$MYSQL_TMP_DIR/galera_check-perl.log")
+# --replace_result $pxc_scheduler_handler_script SCHEDULER_SCRIPT $MYSQL_TMP_DIR MYSQL_TMP_DIR
+# --eval INSERT INTO scheduler (id,active,interval_ms,filename,arg1) values (10,1,3000,"$pxc_scheduler_handler_script","-u=admin -p=admin -h=127.0.0.1 -H=$wHG:W,$rHG:R -P=6032 --debug=1 --active_failover=1 --retry_down=2 --writer_is_also_reader=0 --log=$MYSQL_TMP_DIR/galera_check-perl.log")
 # The following line works with Golang
---replace_result $proxysql_scheduler_script SCHEDULER_SCRIPT $proxysql_scheduler_config_dir CONFIG_DIR
---eval INSERT INTO scheduler (id,active,interval_ms,filename,arg1,arg2) values (10,1,3000,"$proxysql_scheduler_script","--configfile=$proxysql_scheduler_config", "--configpath=$proxysql_scheduler_config_dir")
+--replace_result $pxc_scheduler_handler_script SCHEDULER_SCRIPT $pxc_scheduler_handler_config_dir CONFIG_DIR
+--eval INSERT INTO scheduler (id,active,interval_ms,filename,arg1,arg2) values (10,1,3000,"$pxc_scheduler_handler_script","--configfile=$pxc_scheduler_handler_config", "--configpath=$pxc_scheduler_handler_config_dir")
 
 --source ../include/apply_proxysql_config.inc
 

--- a/mtr/proxysql/t/2w3r2bw_2actions.inc
+++ b/mtr/proxysql/t/2w3r2bw_2actions.inc
@@ -4,7 +4,7 @@
 #  node_1: writer
 #  node_2: reader / backup writer
 #  node_3: reader / backup writer
-# 3. Setup ProxySQL scheduler with config passed in $proxysql_scheduler_config
+# 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config
 # 4. Connect to $action_1_node and perform $action_1
 # 5. Validate ProxySQL configuration
 # 6. Connect to $action_2_node and perform $action_2
@@ -20,7 +20,7 @@
 --source ../include/common_pxc_init.inc
 
 # Check if ProxySQL scheduler config exists
---file_exists $proxysql_scheduler_config_dir/$proxysql_scheduler_config
+--file_exists $pxc_scheduler_handler_config_dir/$pxc_scheduler_handler_config
 
 #
 # ARRANGE
@@ -69,11 +69,11 @@
 #--let $scheduler_script=/home/kamil/repo/pxc/8.0/install/proxysql/galera_check.pl
 
 # The following line works with Perl
-# --replace_result $proxysql_scheduler_script SCHEDULER_SCRIPT $MYSQL_TMP_DIR MYSQL_TMP_DIR
-# --eval INSERT INTO scheduler (id,active,interval_ms,filename,arg1) values (10,1,3000,"$proxysql_scheduler_script","-u=admin -p=admin -h=127.0.0.1 -H=$wHG:W,$rHG:R -P=6032 --debug=1 --active_failover=1 --retry_down=2 --writer_is_also_reader=0 --log=$MYSQL_TMP_DIR/galera_check-perl.log")
+# --replace_result $pxc_scheduler_handler_script SCHEDULER_SCRIPT $MYSQL_TMP_DIR MYSQL_TMP_DIR
+# --eval INSERT INTO scheduler (id,active,interval_ms,filename,arg1) values (10,1,3000,"$pxc_scheduler_handler_script","-u=admin -p=admin -h=127.0.0.1 -H=$wHG:W,$rHG:R -P=6032 --debug=1 --active_failover=1 --retry_down=2 --writer_is_also_reader=0 --log=$MYSQL_TMP_DIR/galera_check-perl.log")
 # The following line works with Golang
---replace_result $proxysql_scheduler_script SCHEDULER_SCRIPT $proxysql_scheduler_config_dir CONFIG_DIR
---eval INSERT INTO scheduler (id,active,interval_ms,filename,arg1,arg2) values (10,1,3000,"$proxysql_scheduler_script","--configfile=$proxysql_scheduler_config", "--configpath=$proxysql_scheduler_config_dir")
+--replace_result $pxc_scheduler_handler_script SCHEDULER_SCRIPT $pxc_scheduler_handler_config_dir CONFIG_DIR
+--eval INSERT INTO scheduler (id,active,interval_ms,filename,arg1,arg2) values (10,1,3000,"$pxc_scheduler_handler_script","--configfile=$pxc_scheduler_handler_config", "--configpath=$pxc_scheduler_handler_config_dir")
 
 --source ../include/apply_proxysql_config.inc
 

--- a/mtr/proxysql/t/pxc_node_kill.inc
+++ b/mtr/proxysql/t/pxc_node_kill.inc
@@ -8,7 +8,7 @@
 #  node_1:          backup reader / backup wrtier
 #  node_2: reader / backup reader / backup writer
 #  node_3: writer / backup reader / backup writer
-# 3. Setup ProxySQL scheduler with config passed in $proxysql_scheduler_config
+# 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config
 # 4. shutdown $node_to_kill
 # 5. start $node_to_kill
 
@@ -21,7 +21,7 @@
 --source ../include/common_pxc_init.inc
 
 # Check if ProxySQL scheduler config exists
---file_exists $proxysql_scheduler_config_dir/$proxysql_scheduler_config
+--file_exists $pxc_scheduler_handler_config_dir/$pxc_scheduler_handler_config
 
 #
 # ARRANGE
@@ -77,11 +77,11 @@
 #--let $scheduler_script=/home/kamil/repo/pxc/8.0/install/proxysql/galera_check.pl
 
 # The following line works with Perl
-# --replace_result $proxysql_scheduler_script SCHEDULER_SCRIPT $MYSQL_TMP_DIR MYSQL_TMP_DIR
-# --eval INSERT INTO scheduler (id,active,interval_ms,filename,arg1) values (10,1,3000,"$proxysql_scheduler_script","-u=admin -p=admin -h=127.0.0.1 -H=$wHG:W,$rHG:R -P=6032 --debug=1 --active_failover=1 --retry_down=2 --writer_is_also_reader=0 --log=$MYSQL_TMP_DIR/galera_check-perl.log")
+# --replace_result $pxc_scheduler_handler_script SCHEDULER_SCRIPT $MYSQL_TMP_DIR MYSQL_TMP_DIR
+# --eval INSERT INTO scheduler (id,active,interval_ms,filename,arg1) values (10,1,3000,"$pxc_scheduler_handler_script","-u=admin -p=admin -h=127.0.0.1 -H=$wHG:W,$rHG:R -P=6032 --debug=1 --active_failover=1 --retry_down=2 --writer_is_also_reader=0 --log=$MYSQL_TMP_DIR/galera_check-perl.log")
 # The following line works with Golang
---replace_result $proxysql_scheduler_script SCHEDULER_SCRIPT $proxysql_scheduler_config_dir CONFIG_DIR
---eval INSERT INTO scheduler (id,active,interval_ms,filename,arg1,arg2) values (10,1,2000,"$proxysql_scheduler_script","--configfile=$proxysql_scheduler_config","--configpath=$proxysql_scheduler_config_dir")
+--replace_result $pxc_scheduler_handler_script SCHEDULER_SCRIPT $pxc_scheduler_handler_config_dir CONFIG_DIR
+--eval INSERT INTO scheduler (id,active,interval_ms,filename,arg1,arg2) values (10,1,2000,"$pxc_scheduler_handler_script","--configfile=$pxc_scheduler_handler_config","--configpath=$pxc_scheduler_handler_config_dir")
 
 --source ../include/apply_proxysql_config.inc
 

--- a/mtr/proxysql/t/reader_add.inc
+++ b/mtr/proxysql/t/reader_add.inc
@@ -4,7 +4,7 @@
 #  node_1: reader/backup wrtier weight 1000
 #  node_2: writer
 #  node_3: reader/backup writer weight 999/backup reader
-# 3. Setup ProxySQL scheduler with config passed in $proxysql_scheduler_config
+# 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config
 # 4. remove all readers from rHG
 # 5. Results depend on WriterIsAlsoReader configuration
 
@@ -17,7 +17,7 @@
 --source ../include/common_pxc_init.inc
 
 # Check if ProxySQL scheduler config exists
---file_exists $proxysql_scheduler_config_dir/$proxysql_scheduler_config
+--file_exists $pxc_scheduler_handler_config_dir/$pxc_scheduler_handler_config
 
 #
 # ARRANGE
@@ -64,11 +64,11 @@
 #--let $scheduler_script=/home/kamil/repo/pxc/8.0/install/proxysql/galera_check.pl
 
 # The following line works with Perl
-# --replace_result $proxysql_scheduler_script SCHEDULER_SCRIPT $MYSQL_TMP_DIR MYSQL_TMP_DIR
-# --eval INSERT INTO scheduler (id,active,interval_ms,filename,arg1) values (10,1,3000,"$proxysql_scheduler_script","-u=admin -p=admin -h=127.0.0.1 -H=$wHG:W,$rHG:R -P=6032 --debug=1 --active_failover=1 --retry_down=2 --writer_is_also_reader=0 --log=$MYSQL_TMP_DIR/galera_check-perl.log")
+# --replace_result $pxc_scheduler_handler_script SCHEDULER_SCRIPT $MYSQL_TMP_DIR MYSQL_TMP_DIR
+# --eval INSERT INTO scheduler (id,active,interval_ms,filename,arg1) values (10,1,3000,"$pxc_scheduler_handler_script","-u=admin -p=admin -h=127.0.0.1 -H=$wHG:W,$rHG:R -P=6032 --debug=1 --active_failover=1 --retry_down=2 --writer_is_also_reader=0 --log=$MYSQL_TMP_DIR/galera_check-perl.log")
 # The following line works with Golang
---replace_result $proxysql_scheduler_script SCHEDULER_SCRIPT $proxysql_scheduler_config_dir CONFIG_DIR
---eval INSERT INTO scheduler (id,active,interval_ms,filename,arg1,arg2) values (10,1,3000,"$proxysql_scheduler_script","--configfile=$proxysql_scheduler_config", "--configpath=$proxysql_scheduler_config_dir")
+--replace_result $pxc_scheduler_handler_script SCHEDULER_SCRIPT $pxc_scheduler_handler_config_dir CONFIG_DIR
+--eval INSERT INTO scheduler (id,active,interval_ms,filename,arg1,arg2) values (10,1,3000,"$pxc_scheduler_handler_script","--configfile=$pxc_scheduler_handler_config", "--configpath=$pxc_scheduler_handler_config_dir")
 
 --source ../include/apply_proxysql_config.inc
 

--- a/mtr/proxysql/t/reader_add1.test
+++ b/mtr/proxysql/t/reader_add1.test
@@ -3,10 +3,10 @@
 #  node_1: reader/backup wrtier weight 1000
 #  node_2: writer
 #  node_3: reader/backup writer weight 999/backup reader
-# 3. Setup ProxySQL scheduler with config passed in $proxysql_scheduler_config
+# 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config
 # 4. remove all readers from rHG
 #   => node_3 added back to rHG
 #   => node_2 added to rHG as WriterIsAlsoReader=true
 
---let $proxysql_scheduler_config = writer_is_reader.toml
+--let $pxc_scheduler_handler_config = writer_is_reader.toml
 --source reader_add.inc

--- a/mtr/proxysql/t/reader_add2.test
+++ b/mtr/proxysql/t/reader_add2.test
@@ -3,10 +3,10 @@
 #  node_1: reader/backup wrtier weight 1000
 #  node_2: writer
 #  node_3: reader/backup writer weight 999/backup reader
-# 3. Setup ProxySQL scheduler with config passed in $proxysql_scheduler_config
+# 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config
 # 4. remove all readers from rHG
 #   => node_3 added back to rHG
 #   => node_2 added to rHG as WriterIsAlsoReader=true
 
---let $proxysql_scheduler_config = writer_is_reader_failback.toml
+--let $pxc_scheduler_handler_config = writer_is_reader_failback.toml
 --source reader_add.inc

--- a/mtr/proxysql/t/reader_add3.test
+++ b/mtr/proxysql/t/reader_add3.test
@@ -3,10 +3,10 @@
 #  node_1: reader/backup wrtier weight 1000
 #  node_2: writer
 #  node_3: reader/backup writer weight 999/backup reader
-# 3. Setup ProxySQL scheduler with config passed in $proxysql_scheduler_config
+# 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config
 # 4. remove all readers from rHG
 #   => node_3 added back to rHG
 #   => node_2 NOT added to rHG as WriterIsAlsoReader=false
 
---let $proxysql_scheduler_config = writer_is_reader_2w.toml
+--let $pxc_scheduler_handler_config = writer_is_reader_2w.toml
 --source reader_add.inc

--- a/mtr/proxysql/t/reader_add4.test
+++ b/mtr/proxysql/t/reader_add4.test
@@ -3,10 +3,10 @@
 #  node_1: reader/backup wrtier weight 1000
 #  node_2: writer
 #  node_3: reader/backup writer weight 999/backup reader
-# 3. Setup ProxySQL scheduler with config passed in $proxysql_scheduler_config
+# 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config
 # 4. remove all readers from rHG
 #   => node_3 added back to rHG
 #   => node_2 NOT added to rHG as WriterIsAlsoReader=false
 
---let $proxysql_scheduler_config = writer_is_not_reader.toml
+--let $pxc_scheduler_handler_config = writer_is_not_reader.toml
 --source reader_add.inc

--- a/mtr/proxysql/t/reader_desync1.test
+++ b/mtr/proxysql/t/reader_desync1.test
@@ -7,7 +7,7 @@
 # 2. node_3: SET global wsrep_desync=0
 #     => node_3 state changes to ONLINE
 
---let $proxysql_scheduler_config = writer_is_reader.toml
+--let $pxc_scheduler_handler_config = writer_is_reader.toml
 --let $action_1_node = node_3
 --let $action_1 = SET global wsrep_desync=1;
 --let $action_2_node = node_3

--- a/mtr/proxysql/t/reader_desync2.test
+++ b/mtr/proxysql/t/reader_desync2.test
@@ -6,7 +6,7 @@
 # 2. node_3: SET global wsrep_desync=0
 #     => node_3  state changes to ONLINE.
 
---let $proxysql_scheduler_config = writer_is_reader_failback.toml
+--let $pxc_scheduler_handler_config = writer_is_reader_failback.toml
 --let $action_1_node = node_3
 --let $action_1 = SET global wsrep_desync=1;
 --let $action_2_node = node_3

--- a/mtr/proxysql/t/reader_desync3.test
+++ b/mtr/proxysql/t/reader_desync3.test
@@ -10,7 +10,7 @@
 #     => node_2 still writer
 #     => node_3  state changes to ONLINE.
 
---let $proxysql_scheduler_config = writer_is_reader_2w.toml
+--let $pxc_scheduler_handler_config = writer_is_reader_2w.toml
 --let $action_1_node = node_3
 --let $action_1 = SET global wsrep_desync=1;
 --let $action_2_node = node_3

--- a/mtr/proxysql/t/reader_desync4.test
+++ b/mtr/proxysql/t/reader_desync4.test
@@ -7,7 +7,7 @@
 # 2. node_3: SET global wsrep_desync=0
 #     => node_3 state changes to ONLINE
 
---let $proxysql_scheduler_config = writer_is_not_reader.toml
+--let $pxc_scheduler_handler_config = writer_is_not_reader.toml
 --let $action_1_node = node_3
 --let $action_1 = SET global wsrep_desync=1;
 --let $action_2_node = node_3

--- a/mtr/proxysql/t/reader_kill1.test
+++ b/mtr/proxysql/t/reader_kill1.test
@@ -3,7 +3,7 @@
 #  node_1:          backup reader / backup wrtier
 #  node_2: reader / backup reader / backup writer
 #  node_3: writer / backup reader / backup writer
-# 3. Setup ProxySQL scheduler with config passed in $proxysql_scheduler_config
+# 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config
 # 4. shutdown reader
 #   => node_3 is reader as WriterIsReader=1
 #   => node_2 status changed to SHUNED, node moved to hostgroup 9100
@@ -11,7 +11,7 @@
 # 5. relaunch reader
 #   => node_2 status changed to ONLINE, node removed from hostgroup 9100, node added to reader hostrgroup 101
 
---let $proxysql_scheduler_config = writer_is_reader.toml
+--let $pxc_scheduler_handler_config = writer_is_reader.toml
 --let $node_1_bwr_priority = 1
 --let $node_2_bwr_priority = 2
 --let $node_3_bwr_priority = 3

--- a/mtr/proxysql/t/reader_kill2.test
+++ b/mtr/proxysql/t/reader_kill2.test
@@ -3,7 +3,7 @@
 #  node_1:          backup reader / backup wrtier
 #  node_2: reader / backup reader / backup writer
 #  node_3: writer / backup reader / backup writer
-# 3. Setup ProxySQL scheduler with config passed in $proxysql_scheduler_config
+# 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config
 # 4. shutdown reader
 #   => node_3 is reader as WriterIsReader=1
 #   => node_2 status changed to SHUNED, node moved to hostgroup 9100
@@ -11,7 +11,7 @@
 # 5. relaunch reader
 #   => node_2 status changed to ONLINE, node removed from hostgroup 9100, node added to reader hostrgroup 101
 
---let $proxysql_scheduler_config = writer_is_reader_failback.toml
+--let $pxc_scheduler_handler_config = writer_is_reader_failback.toml
 --let $node_1_bwr_priority = 1
 --let $node_2_bwr_priority = 2
 --let $node_3_bwr_priority = 3

--- a/mtr/proxysql/t/reader_kill3.test
+++ b/mtr/proxysql/t/reader_kill3.test
@@ -3,7 +3,7 @@
 #  node_1: reader writer / backup reader / backup wrtier
 #  node_2: reader        / backup reader / backup writer
 #  node_3:        writer / backup reader / backup writer
-# 3. Setup ProxySQL scheduler with config passed in $proxysql_scheduler_config
+# 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config
 # 4. shutdown reader node_2
 #   => node_1 reader writer
 #   => node_2 status changed to SHUNED, node moved to hostgroup 9100
@@ -13,7 +13,7 @@
 #   => node_2 status changed to ONLINE, node removed from hostgroup 9100, node added to reader hostrgroup 101
 #   => node_3 writer
 
---let $proxysql_scheduler_config = writer_is_reader_2w.toml
+--let $pxc_scheduler_handler_config = writer_is_reader_2w.toml
 --let $node_1_bwr_priority = 1
 --let $node_2_bwr_priority = 2
 --let $node_3_bwr_priority = 3

--- a/mtr/proxysql/t/reader_kill4.test
+++ b/mtr/proxysql/t/reader_kill4.test
@@ -3,14 +3,14 @@
 #  node_1:          backup reader / backup wrtier
 #  node_2: reader / backup reader / backup writer
 #  node_3: writer / backup reader / backup writer
-# 3. Setup ProxySQL scheduler with config passed in $proxysql_scheduler_config
+# 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config
 # 4. shutdown reader
 #   => node_2 status changed to SHUNED, node moved to hostgroup 9100
 #   => node_1 promoted to reader
 # 5. relaunch reader
 #   => node_2 status changed to ONLINE, node removed from hostgroup 9100, node added to reader hostrgroup 101
 
---let $proxysql_scheduler_config = writer_is_not_reader.toml
+--let $pxc_scheduler_handler_config = writer_is_not_reader.toml
 --let $node_1_bwr_priority = 1
 --let $node_2_bwr_priority = 2
 --let $node_3_bwr_priority = 3

--- a/mtr/proxysql/t/reader_reject_queries1.test
+++ b/mtr/proxysql/t/reader_reject_queries1.test
@@ -6,7 +6,7 @@
 # 2. node_3: SET GLOBAL wsrep_reject_queries=NONE
 #     => node_3 goes back hostgroup 101
 
---let $proxysql_scheduler_config = writer_is_reader.toml
+--let $pxc_scheduler_handler_config = writer_is_reader.toml
 --let $action_1_node = node_3
 --let $action_1 = SET GLOBAL wsrep_reject_queries=ALL;
 --let $action_2_node = node_3

--- a/mtr/proxysql/t/reader_reject_queries2.test
+++ b/mtr/proxysql/t/reader_reject_queries2.test
@@ -6,7 +6,7 @@
 # 2. node_3: SET GLOBAL wsrep_reject_queries=NONE
 #     => node_3 goes back hostgroup 101
 
---let $proxysql_scheduler_config = writer_is_reader_failback.toml
+--let $pxc_scheduler_handler_config = writer_is_reader_failback.toml
 --let $action_1_node = node_3
 --let $action_1 = SET GLOBAL wsrep_reject_queries=ALL;
 --let $action_2_node = node_3

--- a/mtr/proxysql/t/reader_reject_queries3.test
+++ b/mtr/proxysql/t/reader_reject_queries3.test
@@ -10,7 +10,7 @@
 #     => node_2 still writer
 #     => node_3 goes back hostgroup 101
 
---let $proxysql_scheduler_config = writer_is_reader_2w.toml
+--let $pxc_scheduler_handler_config = writer_is_reader_2w.toml
 --let $action_1_node = node_3
 --let $action_1 = SET GLOBAL wsrep_reject_queries=ALL;
 --let $action_2_node = node_3

--- a/mtr/proxysql/t/reader_reject_queries4.test
+++ b/mtr/proxysql/t/reader_reject_queries4.test
@@ -6,7 +6,7 @@
 # 2. node_3: SET GLOBAL wsrep_reject_queries=NONE
 #     => node_3 goes back hostgroup 101
 
---let $proxysql_scheduler_config = writer_is_not_reader.toml
+--let $pxc_scheduler_handler_config = writer_is_not_reader.toml
 --let $action_1_node = node_3
 --let $action_1 = SET GLOBAL wsrep_reject_queries=ALL;
 --let $action_2_node = node_3

--- a/mtr/proxysql/t/reader_to_maintenance1.test
+++ b/mtr/proxysql/t/reader_to_maintenance1.test
@@ -7,7 +7,7 @@
 # 2. node_2: set pxc_maint_mode=DISABLED
 #     => node_2 state changes to ONLINE. Node still in readers
 
---let $proxysql_scheduler_config = writer_is_reader.toml
+--let $pxc_scheduler_handler_config = writer_is_reader.toml
 --let $action_1_node = node_2
 --let $action_1 = SET global pxc_maint_mode=MAINTENANCE;
 --let $action_2_node = node_2

--- a/mtr/proxysql/t/reader_to_maintenance2.test
+++ b/mtr/proxysql/t/reader_to_maintenance2.test
@@ -7,7 +7,7 @@
 # 2. node_2: set pxc_maint_mode=DISABLED
 #     => node_2 state changes to ONLINE. Node still in readers
 
---let $proxysql_scheduler_config = writer_is_reader_failback.toml
+--let $pxc_scheduler_handler_config = writer_is_reader_failback.toml
 --let $action_1_node = node_2
 --let $action_1 = SET global pxc_maint_mode=MAINTENANCE;
 --let $action_2_node = node_2

--- a/mtr/proxysql/t/reader_to_maintenance3.test
+++ b/mtr/proxysql/t/reader_to_maintenance3.test
@@ -11,7 +11,7 @@
 #     => node_2 still writer
 #     => node_3 state changes to ONLINE. reader
 
---let $proxysql_scheduler_config = writer_is_reader_2w.toml
+--let $pxc_scheduler_handler_config = writer_is_reader_2w.toml
 --let $action_1_node = node_3
 --let $action_1 = SET global pxc_maint_mode=MAINTENANCE;
 --let $action_2_node = node_3

--- a/mtr/proxysql/t/reader_to_maintenance4.test
+++ b/mtr/proxysql/t/reader_to_maintenance4.test
@@ -7,7 +7,7 @@
 # 2. node_2: set pxc_maint_mode=DISABLED
 #     => node_2 state changes to ONLINE. Node still in readers
 
---let $proxysql_scheduler_config = writer_is_not_reader.toml
+--let $pxc_scheduler_handler_config = writer_is_not_reader.toml
 --let $action_1_node = node_2
 --let $action_1 = SET global pxc_maint_mode=MAINTENANCE;
 --let $action_2_node = node_2

--- a/mtr/proxysql/t/reader_to_readonly1.test
+++ b/mtr/proxysql/t/reader_to_readonly1.test
@@ -6,7 +6,7 @@
 # 2. node_2: SET GLOBAL read_only=0
 #     => node_2 stays reader
 
---let $proxysql_scheduler_config = writer_is_reader.toml
+--let $pxc_scheduler_handler_config = writer_is_reader.toml
 --let $action_1_node = node_2
 --let $action_1 = SET GLOBAL read_only=1;
 --let $action_2_node = node_2

--- a/mtr/proxysql/t/reader_to_readonly2.test
+++ b/mtr/proxysql/t/reader_to_readonly2.test
@@ -6,7 +6,7 @@
 # 2. node_2: SET GLOBAL read_only=0
 #     => node_2 stays reader
 
---let $proxysql_scheduler_config = writer_is_reader_failback.toml
+--let $pxc_scheduler_handler_config = writer_is_reader_failback.toml
 --let $action_1_node = node_2
 --let $action_1 = SET GLOBAL read_only=1;
 --let $action_2_node = node_2

--- a/mtr/proxysql/t/reader_to_readonly3.test
+++ b/mtr/proxysql/t/reader_to_readonly3.test
@@ -10,7 +10,7 @@
 #     => node_2 still writer
 #     => node_3 stays reader
 
---let $proxysql_scheduler_config = writer_is_reader_2w.toml
+--let $pxc_scheduler_handler_config = writer_is_reader_2w.toml
 --let $action_1_node = node_3
 --let $action_1 = SET GLOBAL read_only=1;
 --let $action_2_node = node_3

--- a/mtr/proxysql/t/reader_to_readonly4.test
+++ b/mtr/proxysql/t/reader_to_readonly4.test
@@ -6,7 +6,7 @@
 # 2. node_2: SET GLOBAL read_only=0
 #     => node_2 stays reader
 
---let $proxysql_scheduler_config = writer_is_not_reader.toml
+--let $pxc_scheduler_handler_config = writer_is_not_reader.toml
 --let $action_1_node = node_2
 --let $action_1 = SET GLOBAL read_only=1;
 --let $action_2_node = node_2

--- a/mtr/proxysql/t/writer_add.inc
+++ b/mtr/proxysql/t/writer_add.inc
@@ -4,7 +4,7 @@
 #  node_1: reader
 #  node_2: writer/backup writer
 #  node_3: reader/backup reader
-# 3. Setup ProxySQL scheduler with config passed in $proxysql_scheduler_config
+# 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config
 # 4. remove all readers from rHG
 # 5. Results depend on WriterIsAlsoReader configuration
 
@@ -17,7 +17,7 @@
 --source ../include/common_pxc_init.inc
 
 # Check if ProxySQL scheduler config exists
---file_exists $proxysql_scheduler_config_dir/$proxysql_scheduler_config
+--file_exists $pxc_scheduler_handler_config_dir/$pxc_scheduler_handler_config
 
 #
 # ARRANGE
@@ -66,11 +66,11 @@
 #--let $scheduler_script=/home/kamil/repo/pxc/8.0/install/proxysql/galera_check.pl
 
 # The following line works with Perl
-# --replace_result $proxysql_scheduler_script SCHEDULER_SCRIPT $MYSQL_TMP_DIR MYSQL_TMP_DIR
-# --eval INSERT INTO scheduler (id,active,interval_ms,filename,arg1) values (10,1,3000,"$proxysql_scheduler_script","-u=admin -p=admin -h=127.0.0.1 -H=$wHG:W,$rHG:R -P=6032 --debug=1 --active_failover=1 --retry_down=2 --writer_is_also_reader=0 --log=$MYSQL_TMP_DIR/galera_check-perl.log")
+# --replace_result $pxc_scheduler_handler_script SCHEDULER_SCRIPT $MYSQL_TMP_DIR MYSQL_TMP_DIR
+# --eval INSERT INTO scheduler (id,active,interval_ms,filename,arg1) values (10,1,3000,"$pxc_scheduler_handler_script","-u=admin -p=admin -h=127.0.0.1 -H=$wHG:W,$rHG:R -P=6032 --debug=1 --active_failover=1 --retry_down=2 --writer_is_also_reader=0 --log=$MYSQL_TMP_DIR/galera_check-perl.log")
 # The following line works with Golang
---replace_result $proxysql_scheduler_script SCHEDULER_SCRIPT $proxysql_scheduler_config_dir CONFIG_DIR
---eval INSERT INTO scheduler (id,active,interval_ms,filename,arg1,arg2) values (10,1,3000,"$proxysql_scheduler_script","--configfile=$proxysql_scheduler_config", "--configpath=$proxysql_scheduler_config_dir")
+--replace_result $pxc_scheduler_handler_script SCHEDULER_SCRIPT $pxc_scheduler_handler_config_dir CONFIG_DIR
+--eval INSERT INTO scheduler (id,active,interval_ms,filename,arg1,arg2) values (10,1,3000,"$pxc_scheduler_handler_script","--configfile=$pxc_scheduler_handler_config", "--configpath=$pxc_scheduler_handler_config_dir")
 
 --source ../include/apply_proxysql_config.inc
 

--- a/mtr/proxysql/t/writer_add1.test
+++ b/mtr/proxysql/t/writer_add1.test
@@ -3,10 +3,10 @@
 #  node_1: reader
 #  node_2: writer/backup writer weight 2
 #  node_3: reader/backup reader
-# 3. Setup ProxySQL scheduler with config passed in $proxysql_scheduler_config
+# 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config
 # 4. remove all writers from wHG
 #   => node_2 added back to wHG
 #   => node_2 added to rHG as WriterIsAlsoReader=true
 
---let $proxysql_scheduler_config = writer_is_reader.toml
+--let $pxc_scheduler_handler_config = writer_is_reader.toml
 --source writer_add.inc

--- a/mtr/proxysql/t/writer_add2.test
+++ b/mtr/proxysql/t/writer_add2.test
@@ -3,10 +3,10 @@
 #  node_1: reader
 #  node_2: writer/backup writer weight 2
 #  node_3: reader/backup reader
-# 3. Setup ProxySQL scheduler with config passed in $proxysql_scheduler_config
+# 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config
 # 4. remove all writers from wHG
 #   => node_2 added back to wHG
 #   => node_2 added to rHG as WriterIsAlsoReader=true
 
---let $proxysql_scheduler_config = writer_is_reader_failback.toml
+--let $pxc_scheduler_handler_config = writer_is_reader_failback.toml
 --source writer_add.inc

--- a/mtr/proxysql/t/writer_add3.test
+++ b/mtr/proxysql/t/writer_add3.test
@@ -3,10 +3,10 @@
 #  node_1: reader
 #  node_2: writer/backup writer weight 2
 #  node_3: reader/backup reader
-# 3. Setup ProxySQL scheduler with config passed in $proxysql_scheduler_config
+# 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config
 # 4. remove all writers from wHG
 #   => node_2 added back to wHG
 #   => node_2 NOT added to rHG as WriterIsAlsoReader=false
 
---let $proxysql_scheduler_config = writer_is_reader_2w.toml
+--let $pxc_scheduler_handler_config = writer_is_reader_2w.toml
 --source writer_add.inc

--- a/mtr/proxysql/t/writer_add4.test
+++ b/mtr/proxysql/t/writer_add4.test
@@ -3,10 +3,10 @@
 #  node_1: reader
 #  node_2: writer/backup writer weight 2
 #  node_3: reader/backup reader
-# 3. Setup ProxySQL scheduler with config passed in $proxysql_scheduler_config
+# 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config
 # 4. remove all writers from wHG
 #   => node_2 added back to wHG
 #   => node_2 NOT added to rHG as WriterIsAlsoReader=false
 
---let $proxysql_scheduler_config = writer_is_not_reader.toml
+--let $pxc_scheduler_handler_config = writer_is_not_reader.toml
 --source writer_add.inc

--- a/mtr/proxysql/t/writer_desync1.test
+++ b/mtr/proxysql/t/writer_desync1.test
@@ -7,7 +7,7 @@
 # 2. node_1: SET global wsrep_desync=0
 #     => node_1 reader: state changes to ONLINE.
 
---let $proxysql_scheduler_config = writer_is_reader.toml
+--let $pxc_scheduler_handler_config = writer_is_reader.toml
 --let $action_1_node = node_1
 --let $action_1 = SET global wsrep_desync=1;
 --let $action_2_node = node_1

--- a/mtr/proxysql/t/writer_desync2.test
+++ b/mtr/proxysql/t/writer_desync2.test
@@ -7,7 +7,7 @@
 # 2. node_1: SET global wsrep_desync=0
 #     => node_1 reader: state changes to ONLINE.
 
---let $proxysql_scheduler_config = writer_is_reader_failback.toml
+--let $pxc_scheduler_handler_config = writer_is_reader_failback.toml
 --let $action_1_node = node_1
 --let $action_1 = SET global wsrep_desync=1;
 --let $action_2_node = node_1

--- a/mtr/proxysql/t/writer_desync3.test
+++ b/mtr/proxysql/t/writer_desync3.test
@@ -7,7 +7,7 @@
 # 2. node_1: SET global wsrep_desync=0
 #     => node_1 reader: state changes to ONLINE.
 
---let $proxysql_scheduler_config = writer_is_reader_2w.toml
+--let $pxc_scheduler_handler_config = writer_is_reader_2w.toml
 --let $action_1_node = node_1
 --let $action_1 = SET global wsrep_desync=1;
 --let $action_2_node = node_1

--- a/mtr/proxysql/t/writer_desync4.test
+++ b/mtr/proxysql/t/writer_desync4.test
@@ -7,7 +7,7 @@
 # 2. node_1: SET global wsrep_desync=0
 #     => node_1 reader: state changes to ONLINE.
 
---let $proxysql_scheduler_config = writer_is_not_reader.toml
+--let $pxc_scheduler_handler_config = writer_is_not_reader.toml
 --let $action_1_node = node_1
 --let $action_1 = SET global wsrep_desync=1;
 --let $action_2_node = node_1

--- a/mtr/proxysql/t/writer_kill1.test
+++ b/mtr/proxysql/t/writer_kill1.test
@@ -3,7 +3,7 @@
 #  node_1:          backup reader / backup wrtier
 #  node_2: reader / backup reader / backup writer
 #  node_3: writer / backup reader / backup writer
-# 3. Setup ProxySQL scheduler with config passed in $proxysql_scheduler_config
+# 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config
 # 4. shutdown writer
 #   => node_2 promoted to writer, stays reader
 #   => node_3 status changed to SHUNED, node moved to hostgroup 9100
@@ -11,7 +11,7 @@
 #   => node_2 still writer and reader because there is no FailBack
 #   => node_3 status changed to ONLINE, node removed from hostgroup 9100, node added to reader hostrgroup 101
 
---let $proxysql_scheduler_config = writer_is_reader.toml
+--let $pxc_scheduler_handler_config = writer_is_reader.toml
 --let $node_1_bwr_priority = 1
 --let $node_2_bwr_priority = 2
 --let $node_3_bwr_priority = 3

--- a/mtr/proxysql/t/writer_kill2.test
+++ b/mtr/proxysql/t/writer_kill2.test
@@ -3,7 +3,7 @@
 #  node_1:          backup reader / backup wrtier
 #  node_2: reader / backup reader / backup writer
 #  node_3: writer / backup reader / backup writer
-# 3. Setup ProxySQL scheduler with config passed in $proxysql_scheduler_config
+# 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config
 # 4. shutdown writer
 #   => node_2 promoted to writer, stays reader
 #   => node_3 status changed to SHUNED, node moved to hostgroup 9100
@@ -11,7 +11,7 @@
 #   => node_2 removed from writes as it has lower priority than node_3, still reader
 #   => node_3 status changed to ONLINE, node removed from hostgroup 9100, node added to writer hostrgroup 100
 
---let $proxysql_scheduler_config = writer_is_reader_failback.toml
+--let $pxc_scheduler_handler_config = writer_is_reader_failback.toml
 --let $node_1_bwr_priority = 1
 --let $node_2_bwr_priority = 2
 --let $node_3_bwr_priority = 3

--- a/mtr/proxysql/t/writer_kill2b.test
+++ b/mtr/proxysql/t/writer_kill2b.test
@@ -3,7 +3,7 @@
 #  node_1:          backup reader / backup wrtier
 #  node_2: reader / backup reader / backup writer
 #  node_3: writer / backup reader / backup writer
-# 3. Setup ProxySQL scheduler with config passed in $proxysql_scheduler_config
+# 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config
 # 4. shutdown writer
 #   => node_2 promoted to writer, stays reader
 #   => node_3 status changed to SHUNED, node moved to hostgroup 9100
@@ -11,7 +11,7 @@
 #   => node_2 still writer as it has the same proirity as node_3, still reader
 #   => node_3 status changed to ONLINE, node removed from hostgroup 9100, node added to readers
 
---let $proxysql_scheduler_config = writer_is_reader_failback.toml
+--let $pxc_scheduler_handler_config = writer_is_reader_failback.toml
 --let $node_1_bwr_priority = 1
 --let $node_2_bwr_priority = 2
 --let $node_3_bwr_priority = 2

--- a/mtr/proxysql/t/writer_kill3.test
+++ b/mtr/proxysql/t/writer_kill3.test
@@ -3,7 +3,7 @@
 #  node_1: reader writer / backup reader / backup wrtier
 #  node_2: reader        / backup reader / backup writer
 #  node_3:        writer / backup reader / backup writer
-# 3. Setup ProxySQL scheduler with config passed in $proxysql_scheduler_config
+# 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config
 # 4. shutdown writer node_3
 #   => node_1 reader writer
 #   => node_2 promoted to writer, still reader
@@ -13,7 +13,7 @@
 #   => node_2 still writer because there is no FailBack
 #   => node_3 status changed to ONLINE, node removed from hostgroup 9100, node added to reader hostrgroup 101
 
---let $proxysql_scheduler_config = writer_is_reader_2w.toml
+--let $pxc_scheduler_handler_config = writer_is_reader_2w.toml
 --let $node_1_bwr_priority = 1
 --let $node_2_bwr_priority = 2
 --let $node_3_bwr_priority = 3

--- a/mtr/proxysql/t/writer_kill4.test
+++ b/mtr/proxysql/t/writer_kill4.test
@@ -3,7 +3,7 @@
 #  node_1:          backup reader / backup wrtier
 #  node_2: reader / backup reader / backup writer
 #  node_3: writer / backup reader / backup writer
-# 3. Setup ProxySQL scheduler with config passed in $proxysql_scheduler_config
+# 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config
 # 4. shutdown writer
 #   => node_2 promoted to writer, removed from readers
 #   => node_3 status changed to SHUNED, node moved to hostgroup 9100
@@ -11,7 +11,7 @@
 #   => node_2 still writer because there is no FailBack
 #   => node_3 status changed to ONLINE, node removed from hostgroup 9100, node added to reader hostrgroup 101
 
---let $proxysql_scheduler_config = writer_is_not_reader.toml
+--let $pxc_scheduler_handler_config = writer_is_not_reader.toml
 --let $node_1_bwr_priority = 1
 --let $node_2_bwr_priority = 2
 --let $node_3_bwr_priority = 3

--- a/mtr/proxysql/t/writer_reject_queries1.test
+++ b/mtr/proxysql/t/writer_reject_queries1.test
@@ -7,7 +7,7 @@
 # 2. node_1: SET GLOBAL wsrep_reject_queries=NONE
 #     => TODO: what should happen?
 
---let $proxysql_scheduler_config = writer_is_reader.toml
+--let $pxc_scheduler_handler_config = writer_is_reader.toml
 --let $action_1_node = node_1
 --let $action_1 = SET GLOBAL wsrep_reject_queries=ALL;
 --let $action_2_node = node_1

--- a/mtr/proxysql/t/writer_reject_queries2.test
+++ b/mtr/proxysql/t/writer_reject_queries2.test
@@ -8,7 +8,7 @@
 #     => node_1: becomes writer, still reader
 #     => node_3: removed from writers, still reader
 
---let $proxysql_scheduler_config = writer_is_reader_failback.toml
+--let $pxc_scheduler_handler_config = writer_is_reader_failback.toml
 --let $action_1_node = node_1
 --let $action_1 = SET GLOBAL wsrep_reject_queries=ALL;
 --let $action_2_node = node_1

--- a/mtr/proxysql/t/writer_reject_queries3.test
+++ b/mtr/proxysql/t/writer_reject_queries3.test
@@ -10,7 +10,7 @@
 #     => node_2 writer
 #     => node_3 still writers, still reader
 
---let $proxysql_scheduler_config = writer_is_reader_2w.toml
+--let $pxc_scheduler_handler_config = writer_is_reader_2w.toml
 --let $action_1_node = node_1
 --let $action_1 = SET GLOBAL wsrep_reject_queries=ALL;
 --let $action_2_node = node_1

--- a/mtr/proxysql/t/writer_reject_queries4.test
+++ b/mtr/proxysql/t/writer_reject_queries4.test
@@ -7,7 +7,7 @@
 # 2. node_1: SET GLOBAL wsrep_reject_queries=NONE
 #     => TODO: what should happen?
 
---let $proxysql_scheduler_config = writer_is_not_reader.toml
+--let $pxc_scheduler_handler_config = writer_is_not_reader.toml
 --let $action_1_node = node_1
 --let $action_1 = SET GLOBAL wsrep_reject_queries=ALL;
 --let $action_2_node = node_1

--- a/mtr/proxysql/t/writer_to_maintenance1.test
+++ b/mtr/proxysql/t/writer_to_maintenance1.test
@@ -9,7 +9,7 @@
 #     => node_1 state changes to ONLINE. Node moved to readers
 #     => node_3 still writer and reader
 
---let $proxysql_scheduler_config = writer_is_reader.toml
+--let $pxc_scheduler_handler_config = writer_is_reader.toml
 --let $action_1_node = node_1
 --let $action_1 = SET global pxc_maint_mode=MAINTENANCE;
 --let $action_2_node = node_1

--- a/mtr/proxysql/t/writer_to_maintenance2.test
+++ b/mtr/proxysql/t/writer_to_maintenance2.test
@@ -9,7 +9,7 @@
 #     => node_1 state changes to ONLINE. Node becomes writer
 #     => node_2 removed from writers, still reader
 
---let $proxysql_scheduler_config = writer_is_reader_failback.toml
+--let $pxc_scheduler_handler_config = writer_is_reader_failback.toml
 --let $action_1_node = node_1
 --let $action_1 = SET global pxc_maint_mode=MAINTENANCE;
 --let $action_2_node = node_1

--- a/mtr/proxysql/t/writer_to_maintenance3.test
+++ b/mtr/proxysql/t/writer_to_maintenance3.test
@@ -11,7 +11,7 @@
 #     => node_2 still writer
 #     => node_3 still writer
 
---let $proxysql_scheduler_config = writer_is_reader_2w.toml
+--let $pxc_scheduler_handler_config = writer_is_reader_2w.toml
 --let $action_1_node = node_1
 --let $action_1 = SET global pxc_maint_mode=MAINTENANCE;
 --let $action_2_node = node_1

--- a/mtr/proxysql/t/writer_to_maintenance4.test
+++ b/mtr/proxysql/t/writer_to_maintenance4.test
@@ -9,7 +9,7 @@
 #     => node_1 state changes to ONLINE. Node moved to readers only
 #     => node_2 still writer
 
---let $proxysql_scheduler_config = writer_is_not_reader.toml
+--let $pxc_scheduler_handler_config = writer_is_not_reader.toml
 --let $action_1_node = node_1
 --let $action_1 = SET global pxc_maint_mode=MAINTENANCE;
 --let $action_2_node = node_1

--- a/mtr/proxysql/t/writer_to_readonly1.test
+++ b/mtr/proxysql/t/writer_to_readonly1.test
@@ -8,7 +8,7 @@
 #     => node_1 stays reader
 #     => node_3 stays writer (and reader)
 
---let $proxysql_scheduler_config = writer_is_reader.toml
+--let $pxc_scheduler_handler_config = writer_is_reader.toml
 --let $action_1_node = node_1
 --let $action_1 = SET GLOBAL read_only=1;
 --let $action_2_node = node_1

--- a/mtr/proxysql/t/writer_to_readonly2.test
+++ b/mtr/proxysql/t/writer_to_readonly2.test
@@ -8,7 +8,7 @@
 #     => node_1 stays reader and goes back to writer
 #     => node_2 removed from writers, still reader
 
---let $proxysql_scheduler_config = writer_is_reader_failback.toml
+--let $pxc_scheduler_handler_config = writer_is_reader_failback.toml
 --let $action_1_node = node_1
 --let $action_1 = SET GLOBAL read_only=1;
 --let $action_2_node = node_1

--- a/mtr/proxysql/t/writer_to_readonly3.test
+++ b/mtr/proxysql/t/writer_to_readonly3.test
@@ -10,7 +10,7 @@
 #     => node_2 still writer
 #     => node_2 still writer, still reader
 
---let $proxysql_scheduler_config = writer_is_reader_2w.toml
+--let $pxc_scheduler_handler_config = writer_is_reader_2w.toml
 --let $action_1_node = node_1
 --let $action_1 = SET GLOBAL read_only=1;
 --let $action_2_node = node_1

--- a/mtr/proxysql/t/writer_to_readonly4.test
+++ b/mtr/proxysql/t/writer_to_readonly4.test
@@ -8,7 +8,7 @@
 #     => node_1 stays reader
 #     => node_2 stays writer
 
---let $proxysql_scheduler_config = writer_is_not_reader.toml
+--let $pxc_scheduler_handler_config = writer_is_not_reader.toml
 --let $action_1_node = node_1
 --let $action_1 = SET GLOBAL read_only=1;
 --let $action_2_node = node_1


### PR DESCRIPTION
All tests passed successfully

```
==============================================================================
                  TEST NAME                       RESULT  TIME (ms) COMMENT
------------------------------------------------------------------------------
[  2%] proxysql.reader_add1                      [ pass ]  61253
[  4%] proxysql.reader_add2                      [ pass ]  60825
[  6%] proxysql.reader_add3                      [ pass ]  60694
[  8%] proxysql.reader_add4                      [ pass ]  60686
[ 10%] proxysql.reader_desync1                   [ pass ]  60882
[ 12%] proxysql.reader_desync2                   [ pass ]  61190
[ 14%] proxysql.reader_desync3                   [ pass ]  60677
[ 16%] proxysql.reader_desync4                   [ pass ]  60902
[ 18%] proxysql.reader_kill1                     [ pass ]  244088
[ 20%] proxysql.reader_kill2                     [ pass ]  243219
[ 22%] proxysql.reader_kill3                     [ pass ]  242386
[ 24%] proxysql.reader_kill4                     [ pass ]  244017
[ 26%] proxysql.reader_reject_queries1           [ pass ]  61165
[ 28%] proxysql.reader_reject_queries2           [ pass ]  60748
[ 30%] proxysql.reader_reject_queries3           [ pass ]  60626
[ 32%] proxysql.reader_reject_queries4           [ pass ]  60733
[ 34%] proxysql.reader_to_maintenance1           [ pass ]  60625
[ 36%] proxysql.reader_to_maintenance2           [ pass ]  60755
[ 38%] proxysql.reader_to_maintenance3           [ pass ]  60726
[ 40%] proxysql.reader_to_maintenance4           [ pass ]  60946
[ 42%] proxysql.reader_to_readonly1              [ pass ]  62288
[ 44%] proxysql.reader_to_readonly2              [ pass ]  61489
[ 46%] proxysql.reader_to_readonly3              [ pass ]  60995
[ 48%] proxysql.reader_to_readonly4              [ pass ]  61248
[ 50%] proxysql.writer_add1                      [ pass ]  61296
[ 52%] proxysql.writer_add2                      [ pass ]  60818
[ 54%] proxysql.writer_add3                      [ pass ]  60670
[ 56%] proxysql.writer_add4                      [ pass ]  60574
[ 57%] proxysql.writer_desync1                   [ pass ]  61380
[ 60%] proxysql.writer_desync2                   [ pass ]  61376
[ 62%] proxysql.writer_desync3                   [ pass ]  61464
[ 64%] proxysql.writer_desync4                   [ pass ]  60662
[ 66%] proxysql.writer_kill1                     [ pass ]  245999
[ 68%] proxysql.writer_kill2                     [ pass ]  243130
[ 70%] proxysql.writer_kill2b                    [ pass ]  244812
[ 72%] proxysql.writer_kill3                     [ pass ]  244831
[ 74%] proxysql.writer_kill4                     [ pass ]  242589
[ 76%] proxysql.writer_reject_queries1           [ pass ]  61162
[ 78%] proxysql.writer_reject_queries2           [ pass ]  61483
[ 80%] proxysql.writer_reject_queries3           [ pass ]  61239
[ 82%] proxysql.writer_reject_queries4           [ pass ]  60529
[ 84%] proxysql.writer_to_maintenance1           [ pass ]  61002
[ 86%] proxysql.writer_to_maintenance2           [ pass ]  61061
[ 88%] proxysql.writer_to_maintenance3           [ pass ]  61061
[ 90%] proxysql.writer_to_maintenance4           [ pass ]  61196
[ 92%] proxysql.writer_to_readonly1              [ pass ]  60777
[ 94%] proxysql.writer_to_readonly2              [ pass ]  60831
[ 96%] proxysql.writer_to_readonly3              [ pass ]  61042
[ 98%] proxysql.writer_to_readonly4              [ pass ]  61033
[100%] shutdown_report                           [ pass ]       
------------------------------------------------------------------------------
The servers were restarted 0 times
The servers were reinitialized 0 times
Spent 4635.180 of 4821 seconds executing testcases

Completed: All 50 tests were successful.
```
 